### PR TITLE
Changed names of controls for KNX group objects

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.1.0) unstable; urgency=medium
+
+  * Changed names of controls for KNX group objects
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Wed, 08 Dec 2021 08:36:00 +0300
+
 wb-mqtt-knx (1.0.0) unstable; urgency=medium
 
   * Ported to libwbmqtt1

--- a/src/knxgroupobject/mqtt.cpp
+++ b/src/knxgroupobject/mqtt.cpp
@@ -21,8 +21,15 @@ TGroupObjectMqtt::TGroupObjectMqtt(PDpt pDpt,
     auto tx = MqttLocalDevice->GetDriver()->BeginTx();
 
     for (const auto& fieldDescriptor: descriptorList) {
-        auto fullControlId = controlId + "_" + fieldDescriptor.Id;
-        auto fullControlTitle = controlTitle + " [ " + fieldDescriptor.Id + " ]";
+        std::string fullControlId;
+        std::string fullControlTitle;
+        if (descriptorList.size() == 1) {
+            fullControlId = controlId;
+            fullControlTitle = controlTitle;
+        } else {
+            fullControlId = controlId + "_" + fieldDescriptor.Id;
+            fullControlTitle = controlTitle + " ." + fieldDescriptor.Id;
+        }
         auto control = MqttLocalDevice
                            ->CreateControl(tx,
                                            WBMQTT::TControlArgs{}


### PR DESCRIPTION
Изменил title для контролов:
* Для датапоинтов с одним полем убрал посфикс.
* Для датапоинтов с несколькими полями убрал квадратные скобки. Заменил на  " .FieldName" 
