### PR TITLE
41302 Add poll to read group objects

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mqtt-knx (1.3.0) unstable; urgency=medium
+
+  * Added a periodic request for reading group objects of KNX devices.
+  * Added polling timeout.
+  * Added sending read requests for devices at startup.
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Wed, 14 Dec 2021 08:56:00 +0300
+
 wb-mqtt-knx (1.2.0) unstable; urgency=medium
 
   * Extended the range of group address

--- a/src/configurator.cpp
+++ b/src/configurator.cpp
@@ -19,12 +19,11 @@ void Configurator::ConfigureObjectController(IKnxGroupObjectController& controll
             auto groupAddressStr = control["groupAddress"].asString();
             auto dataPointStr = control["dataPointType"].asString();
             auto isReadOnlyBool = control["readOnly"].asBool();
-            auto readPoolTimeout = std::chrono::milliseconds(control["readPoolTimeout"].asInt());
 
             TGroupObjectSettings goSettings;
             goSettings.ReadRequestAfterStart = true;
-            goSettings.ReadRequestPollInterval = std::chrono::milliseconds(control["readPoolInterval"].asInt());
-            goSettings.ReadResponseTimeout = std::chrono::milliseconds(control["readPoolTimeout"].asInt());
+            goSettings.ReadRequestPollInterval = std::chrono::milliseconds(control["readPollInterval"].asInt());
+            goSettings.ReadResponseTimeout = std::chrono::milliseconds(control["readPollTimeout"].asInt());
 
             auto groupObject = groupObjectBuilder.Create({dataPointStr, controlIdStr, controlNameStr, isReadOnlyBool});
             controller.AddGroupObject(knx::TKnxGroupAddress{groupAddressStr}, groupObject, goSettings);

--- a/src/configurator.cpp
+++ b/src/configurator.cpp
@@ -6,6 +6,8 @@ void Configurator::ConfigureObjectController(IKnxGroupObjectController& controll
                                              object::IGroupObjectMqttBuilder& groupObjectBuilder)
 {
     auto devices = ConfigRoot["devices"];
+    auto readPoolInterval = std::chrono::milliseconds(ConfigRoot["readPoolInterval"].asInt());
+
     for (const auto& device: devices) {
         auto deviceIdStr = device["deviceId"].asString();
         auto deviceTitleStr = device["deviceTitle"].asString();
@@ -19,7 +21,6 @@ void Configurator::ConfigureObjectController(IKnxGroupObjectController& controll
             auto dataPointStr = control["dataPointType"].asString();
             auto isReadOnlyBool = control["readOnly"].asBool();
             auto enableReadPool = control["enableReadPool"].asBool();
-            auto readPoolInterval = std::chrono::milliseconds(control["readPoolInterval"].asInt());
 
             auto groupObject = groupObjectBuilder.Create({dataPointStr, controlIdStr, controlNameStr, isReadOnlyBool});
             controller.AddGroupObject(knx::TKnxGroupAddress{groupAddressStr},

--- a/src/configurator.cpp
+++ b/src/configurator.cpp
@@ -6,7 +6,6 @@ void Configurator::ConfigureObjectController(IKnxGroupObjectController& controll
                                              object::IGroupObjectMqttBuilder& groupObjectBuilder)
 {
     auto devices = ConfigRoot["devices"];
-    auto readPoolInterval = std::chrono::milliseconds(ConfigRoot["readPoolInterval"].asInt());
 
     for (const auto& device: devices) {
         auto deviceIdStr = device["deviceId"].asString();
@@ -20,12 +19,16 @@ void Configurator::ConfigureObjectController(IKnxGroupObjectController& controll
             auto groupAddressStr = control["groupAddress"].asString();
             auto dataPointStr = control["dataPointType"].asString();
             auto isReadOnlyBool = control["readOnly"].asBool();
-            auto enableReadPool = control["enableReadPool"].asBool();
+            auto readPoolTimeout = std::chrono::milliseconds(control["readPoolTimeout"].asInt());
+
+            TGroupObjectSettings goSettings;
+            goSettings.ReadRequestAfterStart = true;
+            goSettings.ReadRequestPollInterval = std::chrono::milliseconds(control["readPoolInterval"].asInt());
+            goSettings.ReadResponseTimeout = std::chrono::milliseconds(control["readPoolTimeout"].asInt());
 
             auto groupObject = groupObjectBuilder.Create({dataPointStr, controlIdStr, controlNameStr, isReadOnlyBool});
             controller.AddGroupObject(knx::TKnxGroupAddress{groupAddressStr},
-                                      groupObject,
-                                      enableReadPool ? readPoolInterval : std::chrono::milliseconds::zero());
+                                      groupObject,goSettings);
         }
 
         groupObjectBuilder.RemoveUnusedControls();

--- a/src/configurator.cpp
+++ b/src/configurator.cpp
@@ -27,8 +27,7 @@ void Configurator::ConfigureObjectController(IKnxGroupObjectController& controll
             goSettings.ReadResponseTimeout = std::chrono::milliseconds(control["readPoolTimeout"].asInt());
 
             auto groupObject = groupObjectBuilder.Create({dataPointStr, controlIdStr, controlNameStr, isReadOnlyBool});
-            controller.AddGroupObject(knx::TKnxGroupAddress{groupAddressStr},
-                                      groupObject,goSettings);
+            controller.AddGroupObject(knx::TKnxGroupAddress{groupAddressStr}, groupObject, goSettings);
         }
 
         groupObjectBuilder.RemoveUnusedControls();

--- a/src/configurator.cpp
+++ b/src/configurator.cpp
@@ -18,9 +18,13 @@ void Configurator::ConfigureObjectController(IKnxGroupObjectController& controll
             auto groupAddressStr = control["groupAddress"].asString();
             auto dataPointStr = control["dataPointType"].asString();
             auto isReadOnlyBool = control["readOnly"].asBool();
+            auto enableReadPool = control["enableReadPool"].asBool();
+            auto readPoolInterval = std::chrono::milliseconds(control["readPoolInterval"].asInt());
 
             auto groupObject = groupObjectBuilder.Create({dataPointStr, controlIdStr, controlNameStr, isReadOnlyBool});
-            controller.AddGroupObject(knx::TKnxGroupAddress{groupAddressStr}, groupObject);
+            controller.AddGroupObject(knx::TKnxGroupAddress{groupAddressStr},
+                                      groupObject,
+                                      enableReadPool ? readPoolInterval : std::chrono::milliseconds::zero());
         }
 
         groupObjectBuilder.RemoveUnusedControls();

--- a/src/iknxgroupobjectcontroller.h
+++ b/src/iknxgroupobjectcontroller.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#pragma once
 #include "knxgroupaddress.h"
 #include "knxgroupobject/igroupobject.h"
 #include "knxtelegram.h"
@@ -10,6 +9,13 @@
 
 namespace knx
 {
+    struct TGroupObjectSettings
+    {
+        bool ReadRequestAfterStart{false};
+        std::chrono::milliseconds ReadRequestPollInterval{0};
+        std::chrono::milliseconds ReadResponseTimeout{0};
+    };
+
     /// Class containing group objects and routing incoming KNX messages to group objects
     class IKnxGroupObjectController
     {
@@ -17,11 +23,11 @@ namespace knx
         /// Add group object to controller
         /// \param groupAddress group address associated with a group object
         /// \param groupObject group object for management
-        /// \param pollInterval read poll interval
+        /// \param settings group object settings
         /// \return The group object has been successfully added to the controller
         virtual bool AddGroupObject(const knx::TKnxGroupAddress& groupAddress,
                                     const object::PGroupObject& groupObject,
-                                    std::chrono::milliseconds pollInterval) = 0;
+                                    const TGroupObjectSettings& settings) = 0;
 
         /// Remove group object from controller
         /// \param groupAddress group address associated with a group object

--- a/src/iknxgroupobjectcontroller.h
+++ b/src/iknxgroupobjectcontroller.h
@@ -9,11 +9,13 @@
 
 namespace knx
 {
+    /// Group object settings
     struct TGroupObjectSettings
     {
-        bool ReadRequestAfterStart{false};
-        std::chrono::milliseconds ReadRequestPollInterval{0};
-        std::chrono::milliseconds ReadResponseTimeout{0};
+        bool ReadRequestAfterStart{false}; ///< Send a read request after the start of the knxd client
+        std::chrono::milliseconds ReadRequestPollInterval{0}; ///< Period of sending a read request
+        std::chrono::milliseconds ReadResponseTimeout{0};     ///< Time to wait for a response to a read request
+                                                              ///< Must be less than the polling period.
     };
 
     /// Class containing group objects and routing incoming KNX messages to group objects

--- a/src/iknxgroupobjectcontroller.h
+++ b/src/iknxgroupobjectcontroller.h
@@ -17,9 +17,11 @@ namespace knx
         /// Add group object to controller
         /// \param groupAddress group address associated with a group object
         /// \param groupObject group object for management
+        /// \param pollInterval read poll interval
         /// \return The group object has been successfully added to the controller
         virtual bool AddGroupObject(const knx::TKnxGroupAddress& groupAddress,
-                                    const object::PGroupObject& groupObject) = 0;
+                                    const object::PGroupObject& groupObject,
+                                    std::chrono::milliseconds pollInterval) = 0;
 
         /// Remove group object from controller
         /// \param groupAddress group address associated with a group object

--- a/src/knxclientservice.cpp
+++ b/src/knxclientservice.cpp
@@ -172,6 +172,7 @@ namespace knx
                                                       &destEibAddress);
             if (packetLen == EIB_ERROR_RETURN_VALUE) {
                 HandleLoopError(std::string("Failed to get a group TPDU: ") + std::strerror(errno));
+                NotifyAllSubscribers(TTelegram{},TKnxError::KnxdSocketError);
                 break;
             }
 
@@ -188,7 +189,7 @@ namespace knx
                 if (DebugLogger.IsEnabled()) {
                     DebugLogger.Log() << "Received from knxd: " << ToLog(knxTelegram);
                 }
-                NotifyAllSubscribers(knxTelegram);
+                NotifyAllSubscribers(knxTelegram, TKnxError::None);
             } catch (const TKnxException& e) {
                 ErrorLogger.Log() << e.what();
             } catch (const std::exception& e) {

--- a/src/knxclientservice.h
+++ b/src/knxclientservice.h
@@ -11,8 +11,7 @@
 namespace knx
 {
     /// \brief Class for transmitting and receiving KNX telegrams
-    class TKnxClientService: public ISender<TTelegram>,
-                             public TObserver<TKnxEvent, TTelegram>
+    class TKnxClientService: public ISender<TTelegram>, public TObserver<TKnxEvent, TTelegram>
     {
     public:
         /// Constructor

--- a/src/knxclientservice.h
+++ b/src/knxclientservice.h
@@ -2,7 +2,7 @@
 
 #include "isender.h"
 #include "knxconnection.h"
-#include "knxerror.h"
+#include "knxevent.h"
 #include "knxtelegram.h"
 #include "observer.h"
 #include "wblib/log.h"
@@ -12,7 +12,7 @@ namespace knx
 {
     /// \brief Class for transmitting and receiving KNX telegrams
     class TKnxClientService: public ISender<TTelegram>,
-                             public TObserver<TTelegram, TKnxError>
+                             public TObserver<TKnxEvent, TTelegram>
     {
     public:
         /// Constructor

--- a/src/knxclientservice.h
+++ b/src/knxclientservice.h
@@ -2,6 +2,7 @@
 
 #include "isender.h"
 #include "knxconnection.h"
+#include "knxerror.h"
 #include "knxtelegram.h"
 #include "observer.h"
 #include "wblib/log.h"
@@ -10,7 +11,8 @@
 namespace knx
 {
     /// \brief Class for transmitting and receiving KNX telegrams
-    class TKnxClientService: public ISender<TTelegram>, public TObserver<TTelegram>
+    class TKnxClientService: public ISender<TTelegram>,
+                             public TObserver<TTelegram, TKnxError>
     {
     public:
         /// Constructor

--- a/src/knxerror.h
+++ b/src/knxerror.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace knx
+{
+    /// Service errors
+    enum class TKnxError
+    {
+        None = 0,
+        KnxdSocketError,
+        PoolReadTimeoutError
+    };
+}

--- a/src/knxevent.h
+++ b/src/knxevent.h
@@ -3,9 +3,11 @@
 namespace knx
 {
     /// Service errors
-    enum class TKnxError
+    enum class TKnxEvent
     {
         None = 0,
+        ReceivedTelegram,
+        KnxdSocketConnected,
         KnxdSocketError,
         PoolReadTimeoutError
     };

--- a/src/knxevent.h
+++ b/src/knxevent.h
@@ -9,6 +9,6 @@ namespace knx
         ReceivedTelegram,
         KnxdSocketConnected,
         KnxdSocketError,
-        PoolReadTimeoutError
+        PollReadTimeoutError
     };
 }

--- a/src/knxgroupobject/igroupobject.h
+++ b/src/knxgroupobject/igroupobject.h
@@ -17,6 +17,13 @@ namespace knx
             std::vector<uint8_t> Payload; ///< KNX telegram payload
         };
 
+        enum class TGroupObjectError
+        {
+            None = 0,
+            SocketError,
+            PoolReadTimeoutError
+        };
+
         using ISenderGroupObject = ISender<TGroupObjectTransaction>;
         using PSenderGroupObject = std::shared_ptr<ISenderGroupObject>;
 
@@ -27,6 +34,10 @@ namespace knx
             /// Notifying a group object of a message addressed to it
             /// \param transaction Input message from the KNX network
             virtual void KnxNotify(const TGroupObjectTransaction& transaction) = 0;
+
+            /// Notification of a group object about an error in the KNX network
+            /// \param error Error value
+            virtual void KnxError(const TGroupObjectError& error) = 0;
 
             /// Linking the group object to a KNX message transmitter in the network
             /// \param groupAddress the group address to which messages will be sent.

--- a/src/knxgroupobject/igroupobject.h
+++ b/src/knxgroupobject/igroupobject.h
@@ -4,6 +4,7 @@
 #include "../knxgroupaddress.h"
 #include "../knxtelegram.h"
 #include <memory>
+#include "../knxerror.h"
 
 namespace knx
 {
@@ -15,13 +16,6 @@ namespace knx
             TKnxGroupAddress Address;     ///< Destination group address
             telegram::TApci Apci;         ///< Command code for group objects
             std::vector<uint8_t> Payload; ///< KNX telegram payload
-        };
-
-        enum class TGroupObjectError
-        {
-            None = 0,
-            SocketError,
-            PoolReadTimeoutError
         };
 
         using ISenderGroupObject = ISender<TGroupObjectTransaction>;
@@ -37,7 +31,7 @@ namespace knx
 
             /// Notification of a group object about an error in the KNX network
             /// \param error Error value
-            virtual void KnxError(const TGroupObjectError& error) = 0;
+            virtual void KnxNotifyError(const TKnxError& error) = 0;
 
             /// Linking the group object to a KNX message transmitter in the network
             /// \param groupAddress the group address to which messages will be sent.

--- a/src/knxgroupobject/igroupobject.h
+++ b/src/knxgroupobject/igroupobject.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "../isender.h"
+#include "../knxevent.h"
 #include "../knxgroupaddress.h"
 #include "../knxtelegram.h"
 #include <memory>
-#include "../knxevent.h"
 
 namespace knx
 {

--- a/src/knxgroupobject/igroupobject.h
+++ b/src/knxgroupobject/igroupobject.h
@@ -4,7 +4,7 @@
 #include "../knxgroupaddress.h"
 #include "../knxtelegram.h"
 #include <memory>
-#include "../knxerror.h"
+#include "../knxevent.h"
 
 namespace knx
 {
@@ -30,8 +30,8 @@ namespace knx
             virtual void KnxNotify(const TGroupObjectTransaction& transaction) = 0;
 
             /// Notification of a group object about an error in the KNX network
-            /// \param error Error value
-            virtual void KnxNotifyError(const TKnxError& error) = 0;
+            /// \param event Error value
+            virtual void KnxNotifyEvent(const TKnxEvent& event) = 0;
 
             /// Linking the group object to a KNX message transmitter in the network
             /// \param groupAddress the group address to which messages will be sent.

--- a/src/knxgroupobject/mqtt.cpp
+++ b/src/knxgroupobject/mqtt.cpp
@@ -111,3 +111,22 @@ void TGroupObjectMqtt::SetKnxSender(const knx::TKnxGroupAddress& groupAddress, P
     SelfKnxAddress = groupAddress;
     KnxSender = std::move(sender);
 }
+
+void TGroupObjectMqtt::KnxError(const TGroupObjectError& error)
+{
+    std::string errorMessage;
+    switch (error) {
+        case TGroupObjectError::None:
+            return;
+        case TGroupObjectError::PoolReadTimeoutError:
+            errorMessage = "Device not responding to read requests";
+            break;
+        case TGroupObjectError::SocketError:
+            errorMessage = "knxd socket error";
+    }
+
+    auto tx = MqttLocalDevice->GetDriver()->BeginTx();
+    for (const auto& control: ControlList) {
+        control->SetError(tx, errorMessage).Wait();
+    }
+}

--- a/src/knxgroupobject/mqtt.cpp
+++ b/src/knxgroupobject/mqtt.cpp
@@ -122,7 +122,7 @@ void TGroupObjectMqtt::KnxNotifyEvent(const TKnxEvent& event)
         case TKnxEvent::KnxdSocketConnected:
             errorMessage = "";
             break;
-        case TKnxEvent::PoolReadTimeoutError:
+        case TKnxEvent::PollReadTimeoutError:
             errorMessage = "Timed out waiting for a response to a read request";
             break;
         case TKnxEvent::KnxdSocketError:

--- a/src/knxgroupobject/mqtt.cpp
+++ b/src/knxgroupobject/mqtt.cpp
@@ -112,16 +112,16 @@ void TGroupObjectMqtt::SetKnxSender(const knx::TKnxGroupAddress& groupAddress, P
     KnxSender = std::move(sender);
 }
 
-void TGroupObjectMqtt::KnxError(const TGroupObjectError& error)
+void TGroupObjectMqtt::KnxNotifyError(const TKnxError& error)
 {
     std::string errorMessage;
     switch (error) {
-        case TGroupObjectError::None:
+        case TKnxError::None:
             return;
-        case TGroupObjectError::PoolReadTimeoutError:
+        case TKnxError::PoolReadTimeoutError:
             errorMessage = "Device not responding to read requests";
             break;
-        case TGroupObjectError::SocketError:
+        case TKnxError::KnxdSocketError:
             errorMessage = "knxd socket error";
     }
 

--- a/src/knxgroupobject/mqtt.cpp
+++ b/src/knxgroupobject/mqtt.cpp
@@ -112,16 +112,20 @@ void TGroupObjectMqtt::SetKnxSender(const knx::TKnxGroupAddress& groupAddress, P
     KnxSender = std::move(sender);
 }
 
-void TGroupObjectMqtt::KnxNotifyError(const TKnxError& error)
+void TGroupObjectMqtt::KnxNotifyEvent(const TKnxEvent& event)
 {
     std::string errorMessage;
-    switch (error) {
-        case TKnxError::None:
+    switch (event) {
+        case TKnxEvent::None:
+        case TKnxEvent::ReceivedTelegram:
             return;
-        case TKnxError::PoolReadTimeoutError:
-            errorMessage = "Device not responding to read requests";
+        case TKnxEvent::KnxdSocketConnected:
+            errorMessage = "";
             break;
-        case TKnxError::KnxdSocketError:
+        case TKnxEvent::PoolReadTimeoutError:
+            errorMessage = "Remote KNX group object not responding to read requests";
+            break;
+        case TKnxEvent::KnxdSocketError:
             errorMessage = "knxd socket error";
     }
 

--- a/src/knxgroupobject/mqtt.cpp
+++ b/src/knxgroupobject/mqtt.cpp
@@ -123,7 +123,7 @@ void TGroupObjectMqtt::KnxNotifyEvent(const TKnxEvent& event)
             errorMessage = "";
             break;
         case TKnxEvent::PoolReadTimeoutError:
-            errorMessage = "Remote KNX group object not responding to read requests";
+            errorMessage = "Timed out waiting for a response to a read request";
             break;
         case TKnxEvent::KnxdSocketError:
             errorMessage = "knxd socket error";

--- a/src/knxgroupobject/mqtt.h
+++ b/src/knxgroupobject/mqtt.h
@@ -29,7 +29,7 @@ namespace knx
                                       WBMQTT::TLogger& errorLogger);
 
             void KnxNotify(const TGroupObjectTransaction& transaction) override;
-            void KnxNotifyError(const TKnxError& error) override;
+            void KnxNotifyEvent(const TKnxEvent& event) override;
             void SetKnxSender(const TKnxGroupAddress& groupAddress, PSenderGroupObject sender) override;
 
         private:

--- a/src/knxgroupobject/mqtt.h
+++ b/src/knxgroupobject/mqtt.h
@@ -29,7 +29,7 @@ namespace knx
                                       WBMQTT::TLogger& errorLogger);
 
             void KnxNotify(const TGroupObjectTransaction& transaction) override;
-
+            void KnxError(const TGroupObjectError& error) override;
             void SetKnxSender(const TKnxGroupAddress& groupAddress, PSenderGroupObject sender) override;
 
         private:

--- a/src/knxgroupobject/mqtt.h
+++ b/src/knxgroupobject/mqtt.h
@@ -29,7 +29,7 @@ namespace knx
                                       WBMQTT::TLogger& errorLogger);
 
             void KnxNotify(const TGroupObjectTransaction& transaction) override;
-            void KnxError(const TGroupObjectError& error) override;
+            void KnxNotifyError(const TKnxError& error) override;
             void SetKnxSender(const TKnxGroupAddress& groupAddress, PSenderGroupObject sender) override;
 
         private:

--- a/src/knxgroupobjectcontroller.cpp
+++ b/src/knxgroupobjectcontroller.cpp
@@ -2,15 +2,20 @@
 
 using namespace knx;
 
-TKnxGroupObjectController::TKnxGroupObjectController(PSender<TTelegram> pSender): Sender(std::move(pSender))
+TKnxGroupObjectController::TKnxGroupObjectController(PSender<TTelegram> pSender, std::chrono::milliseconds tickInterval)
+    : Sender(std::move(pSender)),
+      TickInterval(tickInterval)
 {}
 
 bool TKnxGroupObjectController::AddGroupObject(const knx::TKnxGroupAddress& groupAddress,
-                                               const object::PGroupObject& groupObject)
+                                               const object::PGroupObject& groupObject,
+                                               std::chrono::milliseconds pollInterval)
 {
     if (groupObject) {
         groupObject->SetKnxSender(groupAddress, shared_from_this());
-        return GroupObjectList.insert({groupAddress, groupObject}).second;
+        return GroupObjectList
+            .insert({groupAddress, {groupObject, static_cast<uint32_t>(pollInterval.count() / TickInterval.count())}})
+            .second;
     }
     return false;
 }
@@ -27,7 +32,7 @@ void TKnxGroupObjectController::Notify(const TTelegram& knxTelegram)
 
         auto groupObjectIterator = GroupObjectList.find(address);
         if (groupObjectIterator != GroupObjectList.end()) {
-            groupObjectIterator->second->KnxNotify(
+            groupObjectIterator->second.groupObject->KnxNotify(
                 {address, knxTelegram.Tpdu().GetAPCI(), knxTelegram.Tpdu().GetPayload()});
         }
     }
@@ -44,4 +49,22 @@ void TKnxGroupObjectController::Send(const object::TGroupObjectTransaction& tran
     knxTelegram.Tpdu().SetPayload(transaction.Payload);
 
     Sender->Send(knxTelegram);
+}
+
+void TKnxGroupObjectController::Notify(const TTickTimerEvent& timerEvent)
+{
+    if (timerEvent == TTickTimerEvent::TimeIsUp) {
+        for (auto& itemPair: GroupObjectList) {
+            auto& address = itemPair.first;
+            auto& item = itemPair.second;
+            if (item.pollInterval) {
+                if (item.counter > 0) {
+                    --item.counter;
+                } else {
+                    item.counter = item.pollInterval;
+                    Send({address, telegram::TApci::GroupValueRead, {0}});
+                }
+            }
+        }
+    }
 }

--- a/src/knxgroupobjectcontroller.cpp
+++ b/src/knxgroupobjectcontroller.cpp
@@ -11,7 +11,7 @@ bool TKnxGroupObjectController::AddGroupObject(const knx::TKnxGroupAddress& grou
                                                const object::PGroupObject& groupObject,
                                                const TGroupObjectSettings& settings)
 {
-    if (groupObject) {
+    if (groupObject && (GroupObjectList.find(groupAddress) == GroupObjectList.end())) {
         groupObject->SetKnxSender(groupAddress, shared_from_this());
 
         auto pItem = std::make_unique<TGroupObjectListItem>();
@@ -21,10 +21,7 @@ bool TKnxGroupObjectController::AddGroupObject(const knx::TKnxGroupAddress& grou
         pItem->Timeout = static_cast<uint32_t>(settings.ReadResponseTimeout.count() / TickInterval.count());
         pItem->Counter = pItem->PollInterval;
 
-        return GroupObjectList
-            .emplace(groupAddress,
-                     std::move(pItem))
-            .second;
+        return GroupObjectList.emplace(groupAddress, std::move(pItem)).second;
     }
     return false;
 }

--- a/src/knxgroupobjectcontroller.cpp
+++ b/src/knxgroupobjectcontroller.cpp
@@ -85,7 +85,7 @@ void TKnxGroupObjectController::Notify(const TTickTimerEvent& timerEvent)
                     --item->TimeoutCounter;
                 } else {
                     item->StartTimeoutTimer = false;
-                    item->GroupObject->KnxNotifyEvent(TKnxEvent::PoolReadTimeoutError);
+                    item->GroupObject->KnxNotifyEvent(TKnxEvent::PollReadTimeoutError);
                 }
             }
 

--- a/src/knxgroupobjectcontroller.cpp
+++ b/src/knxgroupobjectcontroller.cpp
@@ -25,11 +25,11 @@ bool TKnxGroupObjectController::RemoveGroupObject(const TKnxGroupAddress& addres
     return GroupObjectList.erase(address);
 }
 
-void TKnxGroupObjectController::Notify(const TTelegram& knxTelegram, const TKnxError& error)
+void TKnxGroupObjectController::Notify(const TKnxEvent& event, const TTelegram& knxTelegram)
 {
-    if (error != TKnxError::None) {
+    if (event != TKnxEvent::ReceivedTelegram) {
         for (auto& item: GroupObjectList) {
-            item.second.groupObject->KnxNotifyError(error);
+            item.second.groupObject->KnxNotifyEvent(event);
         }
         return;
     }
@@ -72,7 +72,7 @@ void TKnxGroupObjectController::Notify(const TTickTimerEvent& timerEvent)
                     --item.counter;
                 } else {
                     if (item.RequestedRead) {
-                        item.groupObject->KnxNotifyError(TKnxError::PoolReadTimeoutError);
+                        item.groupObject->KnxNotifyEvent(TKnxEvent::PoolReadTimeoutError);
                     }
                     item.counter = item.pollInterval;
                     Send({address, telegram::TApci::GroupValueRead, {0}});

--- a/src/knxgroupobjectcontroller.h
+++ b/src/knxgroupobjectcontroller.h
@@ -32,6 +32,7 @@ namespace knx
             object::PGroupObject groupObject;
             uint32_t pollInterval{0};
             uint32_t counter{0};
+            bool RequestedRead = false;
         };
 
         void Notify(const TTelegram& knxTelegram) override;

--- a/src/knxgroupobjectcontroller.h
+++ b/src/knxgroupobjectcontroller.h
@@ -8,12 +8,12 @@
 #include <map>
 #include <memory>
 #include <utility>
-#include "knxerror.h"
+#include "knxevent.h"
 
 namespace knx
 {
     class TKnxGroupObjectController: public IKnxGroupObjectController,
-                                     public ISubscriber<TTelegram, TKnxError>,
+                                     public ISubscriber<TKnxEvent, TTelegram>,
                                      public ISubscriber<TTickTimerEvent>,
                                      public object::ISenderGroupObject,
                                      public std::enable_shared_from_this<TKnxGroupObjectController>
@@ -36,7 +36,7 @@ namespace knx
             bool RequestedRead = false;
         };
 
-        void Notify(const TTelegram& knxTelegram, const TKnxError& error) override;
+        void Notify( const TKnxEvent& event, const TTelegram& knxTelegram) override;
 
         void Notify(const TTickTimerEvent& timerEvent) override;
 

--- a/src/knxgroupobjectcontroller.h
+++ b/src/knxgroupobjectcontroller.h
@@ -8,11 +8,12 @@
 #include <map>
 #include <memory>
 #include <utility>
+#include "knxerror.h"
 
 namespace knx
 {
     class TKnxGroupObjectController: public IKnxGroupObjectController,
-                                     public ISubscriber<TTelegram>,
+                                     public ISubscriber<TTelegram, TKnxError>,
                                      public ISubscriber<TTickTimerEvent>,
                                      public object::ISenderGroupObject,
                                      public std::enable_shared_from_this<TKnxGroupObjectController>
@@ -35,7 +36,7 @@ namespace knx
             bool RequestedRead = false;
         };
 
-        void Notify(const TTelegram& knxTelegram) override;
+        void Notify(const TTelegram& knxTelegram, const TKnxError& error) override;
 
         void Notify(const TTickTimerEvent& timerEvent) override;
 

--- a/src/knxlegacydevice.cpp
+++ b/src/knxlegacydevice.cpp
@@ -68,10 +68,10 @@ void TKnxLegacyDevice::Deinit()
     }
 }
 
-void TKnxLegacyDevice::Notify(const TTelegram& telegram, const TKnxError&)
+void TKnxLegacyDevice::Notify( const TKnxEvent&, const TTelegram& t)
 {
     try {
-        const auto mqttData = converter::KnxTelegramToMqtt(telegram);
+        const auto mqttData = converter::KnxTelegramToMqtt(t);
         Control->UpdateRawValue(DeviceDriver->BeginTx(), mqttData).Wait();
     } catch (const std::exception& e) {
         ErrorLogger.Log() << e.what();

--- a/src/knxlegacydevice.cpp
+++ b/src/knxlegacydevice.cpp
@@ -68,7 +68,7 @@ void TKnxLegacyDevice::Deinit()
     }
 }
 
-void TKnxLegacyDevice::Notify( const TKnxEvent&, const TTelegram& t)
+void TKnxLegacyDevice::Notify(const TKnxEvent&, const TTelegram& t)
 {
     try {
         const auto mqttData = converter::KnxTelegramToMqtt(t);

--- a/src/knxlegacydevice.cpp
+++ b/src/knxlegacydevice.cpp
@@ -68,7 +68,7 @@ void TKnxLegacyDevice::Deinit()
     }
 }
 
-void TKnxLegacyDevice::Notify(const TTelegram& telegram)
+void TKnxLegacyDevice::Notify(const TTelegram& telegram, const TKnxError&)
 {
     try {
         const auto mqttData = converter::KnxTelegramToMqtt(telegram);

--- a/src/knxlegacydevice.h
+++ b/src/knxlegacydevice.h
@@ -2,6 +2,7 @@
 
 #include "isender.h"
 #include "isubscriber.h"
+#include "knxerror.h"
 #include "knxtelegram.h"
 #include <wblib/log.h>
 #include <wblib/wbmqtt.h>
@@ -9,7 +10,7 @@
 namespace knx
 {
 
-    class TKnxLegacyDevice: public ISubscriber<TTelegram>
+    class TKnxLegacyDevice: public ISubscriber<TTelegram, TKnxError>
     {
     public:
         explicit TKnxLegacyDevice(WBMQTT::PDeviceDriver pMqttDriver,
@@ -20,7 +21,7 @@ namespace knx
 
         void Deinit();
 
-        void Notify(const TTelegram& t) override;
+        void Notify(const TTelegram& t, const TKnxError& error) override;
 
     private:
         WBMQTT::PDeviceDriver DeviceDriver;

--- a/src/knxlegacydevice.h
+++ b/src/knxlegacydevice.h
@@ -2,7 +2,7 @@
 
 #include "isender.h"
 #include "isubscriber.h"
-#include "knxerror.h"
+#include "knxevent.h"
 #include "knxtelegram.h"
 #include <wblib/log.h>
 #include <wblib/wbmqtt.h>
@@ -10,7 +10,7 @@
 namespace knx
 {
 
-    class TKnxLegacyDevice: public ISubscriber<TTelegram, TKnxError>
+    class TKnxLegacyDevice: public ISubscriber<TKnxEvent, TTelegram>
     {
     public:
         explicit TKnxLegacyDevice(WBMQTT::PDeviceDriver pMqttDriver,
@@ -21,7 +21,7 @@ namespace knx
 
         void Deinit();
 
-        void Notify(const TTelegram& t, const TKnxError& error) override;
+        void Notify(const TKnxEvent& event, const TTelegram& t) override;
 
     private:
         WBMQTT::PDeviceDriver DeviceDriver;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ namespace
 {
     const auto KNX_DRIVER_INIT_TIMEOUT_S = std::chrono::seconds(30);
     const auto KNX_DRIVER_STOP_TIMEOUT_S = std::chrono::seconds(60); // topic cleanup can take a lot of time
-    const auto KNX_READ_TICK_PERIOD = std::chrono::milliseconds(100);
+    const auto KNX_READ_TICK_PERIOD = std::chrono::milliseconds(50);
 
     WBMQTT::TLogger ErrorLogger("ERROR: [knx] ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::RED);
     WBMQTT::TLogger VerboseLogger("INFO: [knx] ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::WHITE, false);
@@ -144,9 +144,9 @@ int main(int argc, char** argv)
             knxClientService->Subscribe(knxLegacyDevice);
         }
         knxClientService->Subscribe(knxGroupObjectController);
+        tickTimer.Subscribe(knxGroupObjectController);
 
         configurator.ConfigureObjectController(*knxGroupObjectController, *groupObjectBuilder);
-        tickTimer.Subscribe(knxGroupObjectController);
 
         knxClientService->Start();
         tickTimer.Start();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,7 +143,7 @@ int main(int argc, char** argv)
         if (knxLegacyDevice) {
             knxClientService->Subscribe(knxLegacyDevice);
         }
-        knxClientService->Subscribe(static_cast<knx::PSubscriber<knx::TTelegram, knx::TKnxError>>(knxGroupObjectController));
+        knxClientService->Subscribe(knxGroupObjectController);
 
         configurator.ConfigureObjectController(*knxGroupObjectController, *groupObjectBuilder);
         tickTimer.Subscribe(knxGroupObjectController);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "knxgroupobject/mqttbuilder.h"
 #include "knxgroupobjectcontroller.h"
 #include "knxlegacydevice.h"
+#include "ticktimer.h"
 #include <getopt.h>
 #include <unistd.h>
 #include <wblib/log.h>
@@ -14,6 +15,7 @@ namespace
 {
     const auto KNX_DRIVER_INIT_TIMEOUT_S = std::chrono::seconds(30);
     const auto KNX_DRIVER_STOP_TIMEOUT_S = std::chrono::seconds(60); // topic cleanup can take a lot of time
+    const auto KNX_READ_TICK_PERIOD = std::chrono::milliseconds(100);
 
     WBMQTT::TLogger ErrorLogger("ERROR: [knx] ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::RED);
     WBMQTT::TLogger VerboseLogger("INFO: [knx] ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::WHITE, false);
@@ -116,11 +118,17 @@ int main(int argc, char** argv)
                                                                       VerboseLogger,
                                                                       InfoLogger);
         }
-        auto knxGroupObjectController = std::make_shared<knx::TKnxGroupObjectController>(knxClientService);
+        knx::TTickTimer tickTimer;
+        tickTimer.SetTickPeriod(KNX_READ_TICK_PERIOD);
+        auto knxGroupObjectController =
+            std::make_shared<knx::TKnxGroupObjectController>(knxClientService, KNX_READ_TICK_PERIOD);
 
         auto groupObjectBuilder = std::make_shared<knx::object::TGroupObjectMqttBuilder>(mqttDriver, ErrorLogger);
 
         WBMQTT::SignalHandling::OnSignals({SIGINT, SIGTERM}, [&] {
+            tickTimer.Stop();
+            tickTimer.Unsubscribe(knxGroupObjectController);
+
             knxClientService->Unsubscribe(knxGroupObjectController);
             groupObjectBuilder->Clear();
 
@@ -138,8 +146,10 @@ int main(int argc, char** argv)
         knxClientService->Subscribe(knxGroupObjectController);
 
         configurator.ConfigureObjectController(*knxGroupObjectController, *groupObjectBuilder);
+        tickTimer.Subscribe(knxGroupObjectController);
 
         knxClientService->Start();
+        tickTimer.Start();
 
         initialized.Complete();
         WBMQTT::SignalHandling::Wait();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,7 +143,7 @@ int main(int argc, char** argv)
         if (knxLegacyDevice) {
             knxClientService->Subscribe(knxLegacyDevice);
         }
-        knxClientService->Subscribe(knxGroupObjectController);
+        knxClientService->Subscribe(static_cast<knx::PSubscriber<knx::TTelegram, knx::TKnxError>>(knxGroupObjectController));
 
         configurator.ConfigureObjectController(*knxGroupObjectController, *groupObjectBuilder);
         tickTimer.Subscribe(knxGroupObjectController);

--- a/src/observer.h
+++ b/src/observer.h
@@ -6,9 +6,13 @@
 
 namespace knx
 {
+    /// \brief Base templated class for implementing the observer pattern
     template<typename... Args> class TObserver
     {
     public:
+        /// Add subscriber to subscriber list
+        /// \param subscriber pointer to subscriber
+        /// \return the subscriber has not been added because it is already in the list
         virtual bool Subscribe(PSubscriber<Args...> subscriber)
         {
             auto it = std::find(SubscriberList.begin(), SubscriberList.end(), subscriber);
@@ -19,6 +23,9 @@ namespace knx
             return false;
         }
 
+        /// Remove subscriber to subscriber list
+        /// \param subscriber pointer to subscriber
+        /// \return the subscriber was not deleted because it is not in the list
         virtual bool Unsubscribe(PSubscriber<Args...> subscriber)
         {
             auto it = std::find(SubscriberList.begin(), SubscriberList.end(), subscriber);
@@ -29,9 +36,12 @@ namespace knx
             return false;
         }
 
+        /// Destructor
         virtual ~TObserver() = default;
 
     protected:
+        /// Notify all subscribers
+        /// \param data constant data reference
         virtual void NotifyAllSubscribers(const Args&... data)
         {
             for (const auto& subscriber: SubscriberList) {

--- a/src/ticktimer.cpp
+++ b/src/ticktimer.cpp
@@ -12,7 +12,7 @@ void TTickTimer::Start()
         wb_throw(knx::TKnxException, "Attempt to start already started driver");
     }
 
-    Worker = WBMQTT::MakeThread("KnxClient thread", {[this] { Processing(); }});
+    Worker = WBMQTT::MakeThread("wb-mqtt-knx TimerThread", {[this] { Processing(); }});
 }
 
 void TTickTimer::Stop()

--- a/src/ticktimer.cpp
+++ b/src/ticktimer.cpp
@@ -1,0 +1,39 @@
+#include "ticktimer.h"
+#include "knxexception.h"
+#include "wblib/utils.h"
+
+using namespace knx;
+
+void TTickTimer::Start()
+{
+    bool expectedIsStartedValue = false;
+
+    if (!IsStarted.compare_exchange_strong(expectedIsStartedValue, true)) {
+        wb_throw(knx::TKnxException, "Attempt to start already started driver");
+    }
+
+    Worker = WBMQTT::MakeThread("KnxClient thread", {[this] { Processing(); }});
+}
+
+void TTickTimer::Stop()
+{
+    bool expectedIsStartedValue = true;
+    if (!IsStarted.compare_exchange_strong(expectedIsStartedValue, false)) {
+        wb_throw(knx::TKnxException, "Attempt to stop already stopped TTickTimer");
+    }
+
+    if (Worker->joinable()) {
+        Worker->join();
+    }
+}
+void TTickTimer::Processing()
+{
+    while (IsStarted) {
+        std::this_thread::sleep_for(TickPeriod.load());
+        NotifyAllSubscribers(TTickTimerEvent::TimeIsUp);
+    }
+}
+void TTickTimer::SetTickPeriod(std::chrono::milliseconds period)
+{
+    TickPeriod = period;
+}

--- a/src/ticktimer.h
+++ b/src/ticktimer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "observer.h"
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace knx
+{
+    enum class TTickTimerEvent
+    {
+        TimeIsUp = 0
+    };
+
+    class TTickTimer: public TObserver<TTickTimerEvent>
+    {
+    public:
+        void SetTickPeriod(std::chrono::milliseconds period);
+        void Start();
+        void Stop();
+
+    private:
+        void Processing();
+        std::atomic<bool> IsStarted{false};
+        std::unique_ptr<std::thread> Worker;
+        std::atomic<std::chrono::milliseconds> TickPeriod;
+    };
+}

--- a/src/ticktimer.h
+++ b/src/ticktimer.h
@@ -7,16 +7,24 @@
 
 namespace knx
 {
+    /// Tick timer event
     enum class TTickTimerEvent
     {
-        TimeIsUp = 0
+        TimeIsUp = 0 ///< The time interval has ended
     };
 
+    /// Service for generating periodic events
     class TTickTimer: public TObserver<TTickTimerEvent>
     {
     public:
+        /// Set timer period
+        /// \param period time duration
         void SetTickPeriod(std::chrono::milliseconds period);
+
+        /// Start service
         void Start();
+
+        /// Stop service
         void Stop();
 
     private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(${PROJECT_NAME}_test ${TEST_LIST}
         ../src/knxgroupobject/dpt9.cpp
         ../src/knxgroupobject/dptraw.cpp
         ../src/knxutils.cpp
+        ../src/knxgroupobjectcontroller.cpp
         )
 
 target_link_libraries(${PROJECT_NAME}_test gtest gtest_main gmock wbmqtt1 pthread)

--- a/test/mock/groupobject_mock.h
+++ b/test/mock/groupobject_mock.h
@@ -7,5 +7,6 @@ class TGroupObjectMock: public knx::object::IGroupObject
 {
 public:
     MOCK_METHOD1(KnxNotify, void(const knx::object::TGroupObjectTransaction& transaction));
+    MOCK_METHOD1(KnxNotifyEvent, void(const knx::TKnxEvent& event));
     MOCK_METHOD2(SetKnxSender, void(const knx::TKnxGroupAddress& groupAddress, knx::object::PSenderGroupObject sender));
 };

--- a/test/mock/knxgroupobjectcontroller_mock.h
+++ b/test/mock/knxgroupobjectcontroller_mock.h
@@ -7,7 +7,10 @@
 class TKnxGroupObjectControllerMock: public knx::IKnxGroupObjectController
 {
 public:
-    MOCK_METHOD2(AddGroupObject, bool(const knx::TKnxGroupAddress& groupAddress, const knx::object::PGroupObject&));
+    MOCK_METHOD3(AddGroupObject,
+                 bool(const knx::TKnxGroupAddress& groupAddress,
+                      const knx::object::PGroupObject&,
+                      std::chrono::milliseconds));
     MOCK_METHOD1(RemoveGroupObject, bool(const knx::TKnxGroupAddress& a));
 
     virtual ~TKnxGroupObjectControllerMock() = default;

--- a/test/mock/knxgroupobjectcontroller_mock.h
+++ b/test/mock/knxgroupobjectcontroller_mock.h
@@ -10,7 +10,7 @@ public:
     MOCK_METHOD3(AddGroupObject,
                  bool(const knx::TKnxGroupAddress& groupAddress,
                       const knx::object::PGroupObject&,
-                      std::chrono::milliseconds));
+                      const knx::TGroupObjectSettings&));
     MOCK_METHOD1(RemoveGroupObject, bool(const knx::TKnxGroupAddress& a));
 
     virtual ~TKnxGroupObjectControllerMock() = default;

--- a/test/mock/knxtelegramsender.h
+++ b/test/mock/knxtelegramsender.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#pragma once
+
+#include "../../src/isender.h"
+#include "../../src/knxtelegram.h"
+#include "gmock/gmock.h"
+
+class TTelegramSenderMock: public knx::ISender<knx::TTelegram>
+{
+public:
+    MOCK_METHOD1(Send, void(const knx::TTelegram& telegram));
+};

--- a/test/ut_configurator.cpp
+++ b/test/ut_configurator.cpp
@@ -48,7 +48,7 @@ TEST_F(ConfiguratorTest, CongigureController)
     std::vector<knx::TKnxGroupAddress> addressList{{1, 1, 100}, {1, 2}, {1, 2, 56}, {1, 2, 140}};
 
     for (const auto& groupAddress: addressList) {
-        EXPECT_CALL(*goController, AddGroupObject(groupAddress, _)).Times(1);
+        EXPECT_CALL(*goController, AddGroupObject(groupAddress, _, _)).Times(1);
     }
 
     auto groupObjectMqttBuilder = std::make_shared<TGroupObjectMqttBuilderMock>();

--- a/test/ut_knxgroupobjectcontroller.cpp
+++ b/test/ut_knxgroupobjectcontroller.cpp
@@ -1,0 +1,239 @@
+#include "../src/knxgroupobjectcontroller.h"
+
+#include "../src/observer.h"
+#include "../src/ticktimer.h"
+#include "mock/groupobject_mock.h"
+#include "mock/knxtelegramsender.h"
+#include "gtest/gtest.h"
+#include <utility>
+
+using namespace ::testing;
+
+class TEventObserverStub: public knx::TObserver<knx::TKnxEvent, knx::TTelegram>
+{
+public:
+    void NotifyAll(const knx::TKnxEvent& event, const knx::TTelegram& telegram)
+    {
+        NotifyAllSubscribers(event, telegram);
+    }
+};
+
+class TTickTimerObserverStub: public knx::TObserver<knx::TTickTimerEvent>
+{
+public:
+    void NotifyAll(const knx::TTickTimerEvent& event)
+    {
+        NotifyAllSubscribers(event);
+    }
+};
+
+class KnxGroupObjectControllerTest: public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        TelegramSender = std::make_shared<TTelegramSenderMock>();
+        Controller = std::make_shared<knx::TKnxGroupObjectController>(TelegramSender, TickTime);
+    }
+
+    void TearDown() override
+    {}
+
+    std::shared_ptr<knx::TKnxGroupObjectController> Controller;
+    std::shared_ptr<TTelegramSenderMock> TelegramSender;
+    std::chrono::milliseconds TickTime{10};
+};
+
+TEST_F(KnxGroupObjectControllerTest, AddObject)
+{
+    knx::TKnxGroupAddress address{"1/1/1"};
+    knx::TGroupObjectSettings goSettings;
+    auto groupObjectMock = std::make_shared<TGroupObjectMock>();
+    EXPECT_CALL(*groupObjectMock, SetKnxSender(address, _)).Times(1);
+
+    EXPECT_TRUE(Controller->AddGroupObject(address, groupObjectMock, goSettings));
+    EXPECT_FALSE(Controller->AddGroupObject(address, groupObjectMock, goSettings));
+}
+
+TEST_F(KnxGroupObjectControllerTest, RemoveObject)
+{
+    knx::TKnxGroupAddress address{"1/1/1"};
+    knx::TGroupObjectSettings goSettings;
+    auto groupObjectMock = std::make_shared<TGroupObjectMock>();
+    EXPECT_CALL(*groupObjectMock, SetKnxSender(address, _)).Times(1);
+
+    EXPECT_TRUE(Controller->AddGroupObject(address, groupObjectMock, goSettings));
+    EXPECT_TRUE(Controller->RemoveGroupObject(address));
+    EXPECT_FALSE(Controller->RemoveGroupObject(address));
+}
+
+TEST_F(KnxGroupObjectControllerTest, ReadRequestAfterStart)
+{
+    TEventObserverStub eventObserverStub;
+    TTickTimerObserverStub tickTimerObserverStub;
+
+    knx::TKnxGroupAddress address{"1/1/1"};
+    knx::TGroupObjectSettings goSettings;
+    goSettings.ReadRequestAfterStart = true;
+    auto groupObjectMock = std::make_shared<TGroupObjectMock>();
+    EXPECT_CALL(*groupObjectMock, SetKnxSender(address, _)).Times(1);
+    EXPECT_CALL(*TelegramSender, Send(_)).Times(1);
+
+    EXPECT_TRUE(Controller->AddGroupObject(address, groupObjectMock, goSettings));
+    eventObserverStub.Subscribe(Controller);
+    tickTimerObserverStub.Subscribe(Controller);
+
+    eventObserverStub.NotifyAll(knx::TKnxEvent::KnxdSocketConnected, knx::TTelegram{});
+}
+
+TEST_F(KnxGroupObjectControllerTest, SendTelegram)
+{
+    TEventObserverStub eventObserverStub;
+    TTickTimerObserverStub tickTimerObserverStub;
+    knx::object::PSenderGroupObject goSender;
+
+    knx::TKnxGroupAddress address{"1/1/1"};
+    std::vector<uint8_t> payload = {10, 20};
+
+    knx::TGroupObjectSettings goSettings;
+    goSettings.ReadRequestAfterStart = false;
+    auto groupObjectMock = std::make_shared<TGroupObjectMock>();
+    EXPECT_CALL(*groupObjectMock, SetKnxSender(address, _))
+        .WillOnce(Invoke([&goSender](const knx::TKnxGroupAddress&, knx::object::PSenderGroupObject sender) {
+            goSender = std::move(sender);
+        }));
+    EXPECT_CALL(*TelegramSender, Send(_)).WillOnce(Invoke([&payload, &address](const knx::TTelegram& telegram) {
+        EXPECT_EQ(telegram.Tpdu().GetPayload(), payload);
+        EXPECT_EQ(telegram.GetReceiverAddress(), address.GetEibAddress());
+    }));
+
+    EXPECT_TRUE(Controller->AddGroupObject(address, groupObjectMock, goSettings));
+    goSender->Send(knx::object::TGroupObjectTransaction{address, knx::telegram::TApci::GroupValueWrite, payload});
+    eventObserverStub.Subscribe(Controller);
+    tickTimerObserverStub.Subscribe(Controller);
+
+    eventObserverStub.NotifyAll(knx::TKnxEvent::KnxdSocketConnected, knx::TTelegram{});
+}
+
+TEST_F(KnxGroupObjectControllerTest, RecvTelegram)
+{
+    TEventObserverStub eventObserverStub;
+    TTickTimerObserverStub tickTimerObserverStub;
+
+    knx::TKnxGroupAddress address{"1/1/1"};
+    std::vector<uint8_t> payload = {10, 20};
+
+    knx::TTelegram knxTelegram{};
+    knxTelegram.SetReceiverAddress(address.GetEibAddress());
+    knxTelegram.SetGroupAddressedFlag(true);
+    knxTelegram.Tpdu().SetAPCI(knx::telegram::TApci::GroupValueWrite);
+    knxTelegram.Tpdu().SetPayload(payload);
+
+    knx::TGroupObjectSettings goSettings;
+    goSettings.ReadRequestAfterStart = false;
+    auto groupObjectMock = std::make_shared<TGroupObjectMock>();
+    EXPECT_CALL(*groupObjectMock, SetKnxSender(address, _)).Times(1);
+    EXPECT_CALL(*groupObjectMock, KnxNotify(_))
+        .WillOnce(Invoke([&knxTelegram](const knx::object::TGroupObjectTransaction& transaction) {
+            EXPECT_EQ(knxTelegram.GetReceiverAddress(), transaction.Address.GetEibAddress());
+            EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
+            EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
+        }));
+
+    EXPECT_TRUE(Controller->AddGroupObject(address, groupObjectMock, goSettings));
+
+    eventObserverStub.Subscribe(Controller);
+    tickTimerObserverStub.Subscribe(Controller);
+
+    eventObserverStub.NotifyAll(knx::TKnxEvent::KnxdSocketConnected, knx::TTelegram{});
+    eventObserverStub.NotifyAll(knx::TKnxEvent::ReceivedTelegram, knxTelegram);
+}
+
+TEST_F(KnxGroupObjectControllerTest, PoolRead)
+{
+    TEventObserverStub eventObserverStub;
+    TTickTimerObserverStub tickTimerObserverStub;
+
+    knx::TKnxGroupAddress address{"1/1/1"};
+    std::vector<uint8_t> payload = {10, 20};
+
+    knx::TTelegram knxTelegram{};
+    knxTelegram.SetReceiverAddress(address.GetEibAddress());
+    knxTelegram.SetGroupAddressedFlag(true);
+    knxTelegram.Tpdu().SetAPCI(knx::telegram::TApci::GroupValueResponse);
+    knxTelegram.Tpdu().SetPayload(payload);
+
+    knx::TGroupObjectSettings goSettings;
+    goSettings.ReadRequestAfterStart = false;
+    goSettings.ReadRequestPollInterval = std::chrono::milliseconds(10 * TickTime);
+
+    auto groupObjectMock = std::make_shared<TGroupObjectMock>();
+    EXPECT_CALL(*groupObjectMock, SetKnxSender(address, _)).Times(1);
+    EXPECT_CALL(*groupObjectMock, KnxNotify(_))
+        .WillOnce(Invoke([&knxTelegram](const knx::object::TGroupObjectTransaction& transaction) {
+            EXPECT_EQ(knxTelegram.GetReceiverAddress(), transaction.Address.GetEibAddress());
+            EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
+            EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
+        }));
+
+    EXPECT_TRUE(Controller->AddGroupObject(address, groupObjectMock, goSettings));
+    EXPECT_CALL(*TelegramSender, Send(_)).WillOnce(Invoke([](const knx::TTelegram& telegram) {
+        EXPECT_EQ(telegram.Tpdu().GetAPCI(), knx::telegram::TApci::GroupValueRead);
+    }));
+
+    eventObserverStub.Subscribe(Controller);
+    tickTimerObserverStub.Subscribe(Controller);
+
+    eventObserverStub.NotifyAll(knx::TKnxEvent::KnxdSocketConnected, knx::TTelegram{});
+    for (int i = 0; i < (goSettings.ReadRequestPollInterval / TickTime + 1); ++i) {
+        tickTimerObserverStub.NotifyAll(knx::TTickTimerEvent::TimeIsUp);
+    }
+    eventObserverStub.NotifyAll(knx::TKnxEvent::ReceivedTelegram, knxTelegram);
+}
+
+TEST_F(KnxGroupObjectControllerTest, PoolReadTimeout)
+{
+    TEventObserverStub eventObserverStub;
+    TTickTimerObserverStub tickTimerObserverStub;
+
+    knx::TKnxGroupAddress address{"1/1/1"};
+    std::vector<uint8_t> payload = {10, 20};
+
+    knx::TTelegram knxTelegram{};
+    knxTelegram.SetReceiverAddress(address.GetEibAddress());
+    knxTelegram.SetGroupAddressedFlag(true);
+    knxTelegram.Tpdu().SetAPCI(knx::telegram::TApci::GroupValueResponse);
+    knxTelegram.Tpdu().SetPayload(payload);
+
+    knx::TGroupObjectSettings goSettings;
+    goSettings.ReadRequestAfterStart = false;
+    goSettings.ReadRequestPollInterval = std::chrono::milliseconds(10 * TickTime);
+    goSettings.ReadResponseTimeout = std::chrono::milliseconds(5 * TickTime);
+
+    auto groupObjectMock = std::make_shared<TGroupObjectMock>();
+    EXPECT_CALL(*groupObjectMock, SetKnxSender(address, _)).Times(1);
+    EXPECT_CALL(*groupObjectMock, KnxNotify(_))
+        .WillOnce(Invoke([&knxTelegram](const knx::object::TGroupObjectTransaction& transaction) {
+            EXPECT_EQ(knxTelegram.GetReceiverAddress(), transaction.Address.GetEibAddress());
+            EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
+            EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
+        }));
+
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::PoolReadTimeoutError);
+    }));
+
+    EXPECT_TRUE(Controller->AddGroupObject(address, groupObjectMock, goSettings));
+    EXPECT_CALL(*TelegramSender, Send(_)).WillOnce(Invoke([](const knx::TTelegram& telegram) {
+        EXPECT_EQ(telegram.Tpdu().GetAPCI(), knx::telegram::TApci::GroupValueRead);
+    }));
+
+    eventObserverStub.Subscribe(Controller);
+    tickTimerObserverStub.Subscribe(Controller);
+
+    eventObserverStub.NotifyAll(knx::TKnxEvent::KnxdSocketConnected, knx::TTelegram{});
+    for (int i = 0; i < (2 * goSettings.ReadRequestPollInterval / TickTime - 1); ++i) {
+        tickTimerObserverStub.NotifyAll(knx::TTickTimerEvent::TimeIsUp);
+    }
+    eventObserverStub.NotifyAll(knx::TKnxEvent::ReceivedTelegram, knxTelegram);
+}

--- a/test/ut_knxgroupobjectcontroller.cpp
+++ b/test/ut_knxgroupobjectcontroller.cpp
@@ -149,7 +149,7 @@ TEST_F(KnxGroupObjectControllerTest, RecvTelegram)
     eventObserverStub.NotifyAll(knx::TKnxEvent::ReceivedTelegram, knxTelegram);
 }
 
-TEST_F(KnxGroupObjectControllerTest, PoolRead)
+TEST_F(KnxGroupObjectControllerTest, PollRead)
 {
     TEventObserverStub eventObserverStub;
     TTickTimerObserverStub tickTimerObserverStub;
@@ -191,7 +191,7 @@ TEST_F(KnxGroupObjectControllerTest, PoolRead)
     eventObserverStub.NotifyAll(knx::TKnxEvent::ReceivedTelegram, knxTelegram);
 }
 
-TEST_F(KnxGroupObjectControllerTest, PoolReadTimeout)
+TEST_F(KnxGroupObjectControllerTest, PollReadTimeout)
 {
     TEventObserverStub eventObserverStub;
     TTickTimerObserverStub tickTimerObserverStub;
@@ -220,7 +220,7 @@ TEST_F(KnxGroupObjectControllerTest, PoolReadTimeout)
         }));
 
     EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::PoolReadTimeoutError);
+        EXPECT_EQ(event, knx::TKnxEvent::PollReadTimeoutError);
     }));
 
     EXPECT_TRUE(Controller->AddGroupObject(address, groupObjectMock, goSettings));

--- a/wb-mqtt-knx.schema.json
+++ b/wb-mqtt-knx.schema.json
@@ -81,19 +81,28 @@
           "default": "1.xxx_B1",
           "propertyOrder": 4
         },
-        "enableReadPool": {
-          "type": "boolean",
-          "title": "Enable READ polling",
-          "default": false,
-          "_format": "checkbox",
+        "readPoolInterval": {
+          "type": "integer",
+          "title": "READ poll interval for Devices (ms)",
+          "minimum": 0,
+          "maximum": 100000,
+          "default": 0,
           "propertyOrder": 5
+        },
+        "readPoolTimeout": {
+          "type": "integer",
+          "title": "READ poll timeout for Devices (ms)",
+          "minimum": 0,
+          "maximum": 100000,
+          "default": 0,
+          "propertyOrder": 6
         },
         "readOnly": {
           "type": "boolean",
           "title": "Read only",
           "default": false,
           "_format": "checkbox",
-          "propertyOrder": 6
+          "propertyOrder": 7
         }
       },
       "required": [
@@ -126,14 +135,6 @@
       "default": true,
       "_format": "checkbox",
       "propertyOrder": 3
-    },
-    "readPoolInterval": {
-      "type": "integer",
-      "title": "READ poll interval for Devices (ms)",
-      "minimum": 100,
-      "maximum": 100000,
-      "default": 1000,
-      "propertyOrder": 4
     },
     "devices": {
       "type": "array",

--- a/wb-mqtt-knx.schema.json
+++ b/wb-mqtt-knx.schema.json
@@ -81,20 +81,27 @@
           "default": "1.xxx_B1",
           "propertyOrder": 4
         },
+        "enableReadPool": {
+          "type": "boolean",
+          "title": "Enable READ polling",
+          "default": false,
+          "_format": "checkbox",
+          "propertyOrder": 5
+        },
         "readPoolInterval": {
           "type": "integer",
-          "title": "READ poll interval",
-          "minimum": 10,
-          "maximum" : 100000,
+          "title": "READ poll interval (ms)",
+          "minimum": 100,
+          "maximum": 100000,
           "default": 1000,
-          "propertyOrder": 5
+          "propertyOrder": 6
         },
         "readOnly": {
           "type": "boolean",
           "title": "Read only",
           "default": false,
           "_format": "checkbox",
-          "propertyOrder": 6
+          "propertyOrder": 7
         }
       },
       "required": [

--- a/wb-mqtt-knx.schema.json
+++ b/wb-mqtt-knx.schema.json
@@ -81,12 +81,20 @@
           "default": "1.xxx_B1",
           "propertyOrder": 4
         },
+        "readPoolInterval": {
+          "type": "integer",
+          "title": "READ poll interval",
+          "minimum": 10,
+          "maximum" : 100000,
+          "default": 1000,
+          "propertyOrder": 5
+        },
         "readOnly": {
           "type": "boolean",
           "title": "Read only",
           "default": false,
           "_format": "checkbox",
-          "propertyOrder": 5
+          "propertyOrder": 6
         }
       },
       "required": [

--- a/wb-mqtt-knx.schema.json
+++ b/wb-mqtt-knx.schema.json
@@ -81,7 +81,7 @@
           "default": "1.xxx_B1",
           "propertyOrder": 4
         },
-        "readPoolInterval": {
+        "readPollInterval": {
           "type": "integer",
           "title": "READ poll interval for Devices (ms)",
           "minimum": 0,
@@ -89,7 +89,7 @@
           "default": 0,
           "propertyOrder": 5
         },
-        "readPoolTimeout": {
+        "readPollTimeout": {
           "type": "integer",
           "title": "READ poll timeout for Devices (ms)",
           "minimum": 0,

--- a/wb-mqtt-knx.schema.json
+++ b/wb-mqtt-knx.schema.json
@@ -88,20 +88,12 @@
           "_format": "checkbox",
           "propertyOrder": 5
         },
-        "readPoolInterval": {
-          "type": "integer",
-          "title": "READ poll interval (ms)",
-          "minimum": 100,
-          "maximum": 100000,
-          "default": 1000,
-          "propertyOrder": 6
-        },
         "readOnly": {
           "type": "boolean",
           "title": "Read only",
           "default": false,
           "_format": "checkbox",
-          "propertyOrder": 7
+          "propertyOrder": 6
         }
       },
       "required": [
@@ -135,6 +127,14 @@
       "_format": "checkbox",
       "propertyOrder": 3
     },
+    "readPoolInterval": {
+      "type": "integer",
+      "title": "READ poll interval for Devices (ms)",
+      "minimum": 100,
+      "maximum": 100000,
+      "default": 1000,
+      "propertyOrder": 4
+    },
     "devices": {
       "type": "array",
       "title": "List of Devices",
@@ -143,7 +143,7 @@
       },
       "minItems": 0,
       "_format": "tabs",
-      "propertyOrder": 4,
+      "propertyOrder": 5,
       "options": {
         "disable_collapse": true,
         "disable_array_delete_last_row": true


### PR DESCRIPTION
* Добавлен периодический запрос чтения групповых объектов KNX устройств.
* Добавлен таймаут опроса. Если время ожидания ответа превышено, в топик `/meta/error` для соответствующего контрола публикуется ошибка.
* Добавлена отправка запросов на чтение для всех устройств при старте.