### PR TITLE
Added thread safety for the KNX client service Send() method

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.3.1) unstable; urgency=medium
+
+  * Added thread safety for the KNX Client Service Send() method
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Sat, 25 Dec 2021 18:43:00 +0300
+
 wb-mqtt-knx (1.3.0) unstable; urgency=medium
 
   * Added ETS import tool

--- a/src/knxclientservice.cpp
+++ b/src/knxclientservice.cpp
@@ -60,11 +60,14 @@ namespace knx
 
         if (telegram.IsGroupAddressed()) {
             auto tpduPayload = telegram.Tpdu().GetRaw();
-
-            const int32_t sendResult = EIBSendGroup(KnxdConnection->GetEIBConnection(),
-                                                    telegram.GetReceiverAddress(),
-                                                    static_cast<int32_t>(tpduPayload.size()),
-                                                    tpduPayload.data());
+            int32_t sendResult;
+            {
+                std::lock_guard<std::mutex> lg(SendMutex);
+                sendResult = EIBSendGroup(KnxdConnection->GetEIBConnection(),
+                                          telegram.GetReceiverAddress(),
+                                          static_cast<int32_t>(tpduPayload.size()),
+                                          tpduPayload.data());
+            }
             if (sendResult != EIB_ERROR_RETURN_VALUE) {
                 if (DebugLogger.IsEnabled()) {
                     DebugLogger.Log() << "Sent to knxd: " << ToLog(telegram);

--- a/src/knxclientservice.h
+++ b/src/knxclientservice.h
@@ -46,6 +46,7 @@ namespace knx
 
         std::atomic<bool> IsStarted{false};
         std::unique_ptr<std::thread> Worker;
+        std::mutex SendMutex;
 
         WBMQTT::TLogger& ErrorLogger;
         WBMQTT::TLogger& DebugLogger;


### PR DESCRIPTION
Пролистав исходники knxd обнаружил, что EIBSendGroup() функция библиотеки клиента хоть и блокирует текущий поток, но не потокобезопасна.
Добавил мьютекс в Send(), так как метод вызывается в нескольких потоках.