### PR TITLE
Add value forwarding from MQTT topic /on to the main topic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.4.0) unstable; urgency=medium
+
+  * Added value forwarding from MQTT topic /on to the main topic
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Wed, 29 Dec 2021 19:10:00 +0300
+
 wb-mqtt-knx (1.3.1) unstable; urgency=medium
 
   * Added thread safety for the KNX Client Service Send() method


### PR DESCRIPTION
* Добавил пересылку значения из топика control/on в топик control/
* Исправил баг с деадлоком, возникающий при обработки ошибки преобразования полученного из MQTT значения в значение для KNX датапоинта.