### PR TITLE
45966 Added restrictions to the Device ID and Control ID fields

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.4.2) unstable; urgency=medium
+
+  * Added restrictions to the Device ID and Control ID fields for the JSON schema.
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Tue, 15 Feb 2022 16:19:00 +0300
+
 wb-mqtt-knx (1.4.1) unstable; urgency=medium
 
   * Extended the dpts format for the ETS import tool

--- a/wb-mqtt-knx.schema.json
+++ b/wb-mqtt-knx.schema.json
@@ -50,7 +50,7 @@
         "controlId": {
           "type": "string",
           "title": "Control ID",
-          "pattern": "^[\\w]+$",
+          "pattern": "^[^$#+\\/]+$",
           "options": {
             "patternmessage": "Incorrect Control ID"
           },

--- a/wb-mqtt-knx.schema.json
+++ b/wb-mqtt-knx.schema.json
@@ -10,7 +10,10 @@
         "deviceId": {
           "type": "string",
           "title": "Device ID",
-          "minLength": "1",
+          "pattern": "^[\\w]+$",
+          "options": {
+            "patternmessage": "Incorrect Device ID"
+          },
           "propertyOrder": 1
         },
         "deviceTitle": {
@@ -47,7 +50,10 @@
         "controlId": {
           "type": "string",
           "title": "Control ID",
-          "minLength": "1",
+          "pattern": "^[\\w]+$",
+          "options": {
+            "patternmessage": "Incorrect Control ID"
+          },
           "propertyOrder": 1
         },
         "controlTitle": {

--- a/wb-mqtt-knx.schema.json
+++ b/wb-mqtt-knx.schema.json
@@ -10,7 +10,7 @@
         "deviceId": {
           "type": "string",
           "title": "Device ID",
-          "pattern": "^[\\w]+$",
+          "pattern": "^[^$#+\\/\"']+$",
           "options": {
             "patternmessage": "Incorrect Device ID"
           },
@@ -50,7 +50,7 @@
         "controlId": {
           "type": "string",
           "title": "Control ID",
-          "pattern": "^[^$#+\\/]+$",
+          "pattern": "^[^$#+\\/\"']+$",
           "options": {
             "patternmessage": "Incorrect Control ID"
           },


### PR DESCRIPTION
Добавил в схему конфига регулярные выражения для Device ID и Control ID.
В этих именах разрешены буквы, строчные и заглавные, цифры и знак подчёркивания.