### PR TITLE
Bugfix/clang format update fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
-buildDebSbuild defaultTargets: 'wb6',
+buildDebSbuild defaultTargets: 'current-armhf',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.9.1) unstable; urgency=medium
+
+  * Fix code formatting after clang-format update (15.0-20220704)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 28 Jul 2022 21:47:25 +0300
+
 wb-mqtt-knx (1.9.0) unstable; urgency=medium
 
   *  Added Russian translation to the config schema

--- a/src/knxgroupobject/dptjson.cpp
+++ b/src/knxgroupobject/dptjson.cpp
@@ -68,7 +68,8 @@ namespace knx
                 uint32_t rawValuePosition = 0;
                 for (uint32_t i = (field.BitBeginPosition + field.JsonField.GetBitWidth() - 1);
                      i >= field.BitBeginPosition;
-                     --i) {
+                     --i)
+                {
                     if (field.JsonField.GetRawValue().test(rawValuePosition)) {
                         payload[i / 8] |= (1 << (7 - i % 8));
                     }

--- a/src/knxgroupobject/mqtt.cpp
+++ b/src/knxgroupobject/mqtt.cpp
@@ -77,7 +77,8 @@ void TGroupObjectMqtt::MqttNotify(WBMQTT::PControl& pControl, uint32_t index, co
 void TGroupObjectMqtt::KnxNotify(const TGroupObjectTransaction& transaction)
 {
     if ((transaction.Apci == telegram::TApci::GroupValueWrite) ||
-        (transaction.Apci == telegram::TApci::GroupValueResponse)) {
+        (transaction.Apci == telegram::TApci::GroupValueResponse))
+    {
         std::vector<WBMQTT::TAny> mqttData;
 
         {

--- a/src/knxtelegramtpdu.cpp
+++ b/src/knxtelegramtpdu.cpp
@@ -110,7 +110,8 @@ void TTpdu::SetRaw(std::vector<uint8_t>::const_iterator beginIt, std::vector<uin
     SetSequenceNumber((beginIt[0] >> 2) & 0x0F);
 
     if (CommunicationType == telegram::TCommunicationType::UDP ||
-        CommunicationType == telegram::TCommunicationType::NDP) {
+        CommunicationType == telegram::TCommunicationType::NDP)
+    {
         SetAPCI(static_cast<telegram::TApci>(((beginIt[0] & 0x03) << 2) | (beginIt[1] >> 6)));
         SetPayload(beginIt + 1, endIt);
     } else {


### PR DESCRIPTION
После обновления clang-format-15 (в nightly llvm, до 15.0.0-++20220704093357+5f0a054f8954-1~exp1~20220704093409.365) понадобилось исправить форматирование кода в некоторых местах (оно более правильное согласно конфигурации). Обновление затронуло wb-mqtt-serial и wb-mqtt-knx.

Текущую версию clang-format-15 мы заморозили, доступна в новой сборке devenv. Перед вливанием этого PR (и ещё аналогичного в wb-mqtt-knx) я переключу версию образа devenv на новую и пересоберу этот PR для проверки.