### PR TITLE
debian bullseye support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.8)
 
 project(wb-mqtt-knx)
 
@@ -18,7 +18,7 @@ execute_process (
 include_directories("${PROJECT_BINARY_DIR}")
 
 # specify the C++ standard
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_compile_options(-Wall -Werror -pedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.7)
 
 project(wb-mqtt-knx)
 
@@ -18,7 +18,7 @@ execute_process (
 include_directories("${PROJECT_BINARY_DIR}")
 
 # specify the C++ standard
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_compile_options(-Wall -Werror -pedantic)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
-buildDebSbuild defaultTargets: 'current-armhf',
+buildDebSbuild defaultTargets: 'bullseye-armhf',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
-buildDebSbuild defaultTargets: 'bullseye-armhf',
+buildDebSbuild defaultTargets: 'current-armhf',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mqtt-knx (1.10.0) unstable; urgency=medium
+wb-mqtt-knx (1.10.0) stable; urgency=medium
 
   * Added Debian bullseye-compatible dependencies
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.10.0) unstable; urgency=medium
+
+  * Added Debian bullseye-compatible dependencies
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Mon, 08 Aug 2022 15:24:00 +0400
+
 wb-mqtt-knx (1.9.1) unstable; urgency=medium
 
   * Fix code formatting after clang-format update (15.0-20220704)

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Roman Kochkin <roman.kochkin@wirenboard.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-3-dev (>= 3.2.0), knxd-dev (>= 0.14.51-1), knxd-tools (>= 0.14.51-1), libtinyxml2-dev (>= 8.0.0)
+Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-3-dev (>= 3.2.0), knxd-dev (>= 0.14.51-1), knxd-tools (>= 0.14.51-1), libtinyxml2-dev
 Homepage: https://github.com/wirenboard/wb-mqtt-knx/
 
 Package: wb-mqtt-knx

--- a/debian/control
+++ b/debian/control
@@ -1,13 +1,14 @@
 Source: wb-mqtt-knx
-Maintainer: Yury Usishchev <y.usishchev@contactless.ru>
+Maintainer: Roman Kochkin <roman.kochkin@wirenboard.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-3-dev (>= 3.2.0), knxd-dev (>= 0.14.51-1), knxd-tools (>= 0.14.51-1), libtinyxml2-dev (>= 4.0.1-1)
+Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-3-dev (>= 3.2.0), knxd-dev (>= 0.14.51-1), knxd-tools (>= 0.14.51-1), libtinyxml2-dev (>= 8.0.0)
+Homepage: https://github.com/wirenboard/wb-mqtt-knx/
 
 Package: wb-mqtt-knx
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libwbmqtt1-3 (>= 3.2.0), knxd-tools (>= 0.14.51-1), knxd (>= 0.14.51-1), libtinyxml2-4 (>= 4.0.1-1)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libwbmqtt1-3 (>= 3.2.0), knxd-tools (>= 0.14.51-1), knxd (>= 0.14.51-1)
 Breaks:
 Description: Wiren Board MQTT to KNX gateway
              wb-mqtt-knx service sends unprocessed knx telegrams to mqtt and receives from there


### PR DESCRIPTION
Проверил на контроллере wb6/bullseye.
При сборке под bullseye-armhf на CI lintian ругается и для wb-mqtt-knx и wb-mqtt-mbgate:
![photo_2022-08-11_17-04-10](https://user-images.githubusercontent.com/12100943/184313611-d4102389-f795-45f8-81af-b5938a757899.jpg)

