### PR TITLE
Feature/fixed debug logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories("${PROJECT_BINARY_DIR}")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-add_compile_options(-Wall -Werror -pedantic)
+add_compile_options(-Wall -Werror -pedantic -Wno-psabi)
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     add_compile_options(-O0 -gdwarf-3 --coverage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories("${PROJECT_BINARY_DIR}")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-add_compile_options(-Wall -Werror -pedantic -Wno-psabi)
+add_compile_options(-Wall -Werror -pedantic)
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     add_compile_options(-O0 -gdwarf-3 --coverage)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-knx (1.11.0) stable; urgency=medium
+
+  * More readable log output
+  * Fixed severity level for debug messages
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Fri, 02 Sep 2022 20:05:05 +0400
+
 wb-mqtt-knx (1.10.0) stable; urgency=medium
 
   * Added Debian bullseye-compatible dependencies

--- a/src/knxclientservice.cpp
+++ b/src/knxclientservice.cpp
@@ -1,6 +1,8 @@
 #include "knxclientservice.h"
 #include "knxconnection.h"
 #include "knxexception.h"
+#include "knxgroupaddress.h"
+#include "knxindividualaddress.h"
 #include "wblib/utils.h"
 #include <cstring>
 #include <eibclient.h>
@@ -20,17 +22,19 @@ namespace
     constexpr auto SELECT_TIMEOUT_RETURN_VALUE = 0;
     constexpr auto SELECT_ERROR_RETURN_VALUE = -1;
 
-    std::string ToLog(const knx::TTelegram& telegram)
+    std::string ToLog(const knx::TTelegram& telegram, bool toSend)
     {
         auto tpdu = telegram.Tpdu().GetRaw();
         std::stringstream ss;
-        ss << "S_EIB(" << std::to_string(telegram.GetSourceAddress()) << ") ";
-        ss << "D_EIB(" << std::to_string(telegram.GetReceiverAddress()) << ") ";
-        ss << "TPDU(";
+        if (!toSend) {
+            ss << "from:" << knx::TKnxIndividualAddress(telegram.GetSourceAddress()).ToString() << " ";
+        }
+        ss << "to:" << knx::TKnxGroupAddress(telegram.GetReceiverAddress()).ToString() << " ";
+        ss << "tpdu(";
         ss << tpdu.size() << "):";
         ss << std::hex << std::noshowbase;
         for (unsigned char i: tpdu) {
-            ss << "0x" << std::setw(2) << std::setfill('0');
+            ss << std::setw(2) << std::setfill('0');
             ss << (unsigned)i << " ";
         }
         return ss.str();
@@ -70,7 +74,7 @@ namespace knx
             }
             if (sendResult != EIB_ERROR_RETURN_VALUE) {
                 if (DebugLogger.IsEnabled()) {
-                    DebugLogger.Log() << "Sent to knxd: " << ToLog(telegram);
+                    DebugLogger.Log() << "Sent to knxd: " << ToLog(telegram, true);
                 }
             } else {
                 HandleLoopError("Failed to send group telegram");
@@ -190,7 +194,7 @@ namespace knx
                 knxTelegram.Tpdu().SetRaw(tpduPayload);
 
                 if (DebugLogger.IsEnabled()) {
-                    DebugLogger.Log() << "Received from knxd: " << ToLog(knxTelegram);
+                    DebugLogger.Log() << "Received from knxd: " << ToLog(knxTelegram, false);
                 }
                 NotifyAllSubscribers(TKnxEvent::ReceivedTelegram, knxTelegram);
             } catch (const TKnxException& e) {

--- a/src/knxconverter.cpp
+++ b/src/knxconverter.cpp
@@ -1,6 +1,7 @@
 #include "knxconverter.h"
 #include "knxexception.h"
 #include "knxgroupaddress.h"
+#include "knxindividualaddress.h"
 #include "knxutils.h"
 #include <algorithm>
 #include <array>
@@ -46,11 +47,10 @@ namespace
     std::string KnxSourceAddressToString(const TTelegram& telegram)
     {
         std::stringstream ss;
-        auto address = telegram.GetSourceAddress();
+        TKnxIndividualAddress sourceAddress{telegram.GetSourceAddress()};
 
         // Source address is always individual
-        ss << "i:" << (address >> 12) << "/" << ((address >> 8) & 0xf);
-        ss << "/" << (address & 0xff);
+        ss << "i:" << sourceAddress.ToString('/');
         return ss.str();
     }
 
@@ -63,12 +63,11 @@ namespace
         if (telegram.IsGroupAddressed()) {
             // group address
             TKnxGroupAddress groupAddress{receiverAddress};
-            ss << "g:" << groupAddress.GetMainGroup() << "/" << groupAddress.GetMiddleGroup();
-            ss << "/" << groupAddress.GetSubGroup();
+            ss << "g:" << groupAddress.ToString();
         } else {
             // individual address
-            ss << "i:" << (receiverAddress >> 12) << "/" << ((receiverAddress >> 8) & 0xf);
-            ss << "/" << (receiverAddress & 0xff);
+            TKnxIndividualAddress individualAddress{receiverAddress};
+            ss << "i:" << individualAddress.ToString('/');
         }
 
         return ss.str();

--- a/src/knxindinvidualaddress.cpp
+++ b/src/knxindinvidualaddress.cpp
@@ -1,0 +1,93 @@
+#include "knxindividualaddress.h"
+
+using namespace knx;
+
+namespace
+{
+    constexpr auto AREA_MAX = 15U;
+    constexpr auto LINE_MAX = 15U;
+    constexpr auto DEVICE_ADDRESS_MAX = 255U;
+
+    constexpr auto EIB_ADDRESS_MAX = 0xFFFFU;
+
+    constexpr auto ERROR_MESSAGE = "Invalid KNX Individual Address: ";
+}
+
+TKnxIndividualAddress::TKnxIndividualAddress(uint32_t area, uint32_t line, uint32_t deviceAddress)
+{
+    Init(area, line, deviceAddress);
+}
+
+TKnxIndividualAddress::TKnxIndividualAddress(const std::string& str, char delimiter)
+{
+    auto tokens = WBMQTT::StringSplit(str, delimiter);
+
+    if (tokens.size() == 3) {
+        Init(static_cast<uint32_t>(std::stoi(tokens[0])),
+             static_cast<uint32_t>(std::stoi(tokens[1])),
+             static_cast<uint32_t>(std::stoi(tokens[2])));
+    } else {
+        wb_throw(knx::TKnxException, ERROR_MESSAGE + str);
+    }
+}
+
+TKnxIndividualAddress::TKnxIndividualAddress(eibaddr_t eibAddress)
+{
+    Area = (eibAddress >> 12) & 0xF;
+    Line = (eibAddress >> 8) & 0xF;
+    DeviceAddress = eibAddress & 0xFF;
+}
+
+void TKnxIndividualAddress::Init(uint32_t area, uint32_t line, uint32_t deviceAddress)
+{
+    if ((area > AREA_MAX) || (line > LINE_MAX) || (deviceAddress > DEVICE_ADDRESS_MAX))
+        wb_throw(knx::TKnxException,
+                 ERROR_MESSAGE + std::to_string(area) + "." + std::to_string(line) + "." +
+                     std::to_string(deviceAddress));
+
+    Area = area;
+    Line = line;
+    DeviceAddress = deviceAddress;
+}
+
+eibaddr_t TKnxIndividualAddress::GetEibAddress() const
+{
+    return ((Area & 0xF) << 12) | ((Line & 0xF) << 8) | (DeviceAddress & 0xFF);
+}
+
+bool TKnxIndividualAddress::operator<(const TKnxIndividualAddress& rhs) const
+{
+    return GetEibAddress() < rhs.GetEibAddress();
+}
+
+bool TKnxIndividualAddress::operator==(const TKnxIndividualAddress& rhs) const
+{
+    return ((Area == rhs.Area) && (Line == rhs.Line) && (DeviceAddress == rhs.DeviceAddress));
+}
+
+bool TKnxIndividualAddress::operator!=(const TKnxIndividualAddress& rhs) const
+{
+    return !(*this == rhs);
+}
+
+uint32_t TKnxIndividualAddress::GetArea() const
+{
+    return Area;
+}
+
+uint32_t TKnxIndividualAddress::GetLine() const
+{
+    return Line;
+}
+
+uint32_t TKnxIndividualAddress::GetDeviceAddress() const
+{
+    return DeviceAddress;
+}
+
+std::string TKnxIndividualAddress::ToString(char delimiter) const
+{
+    std::stringstream ss;
+    ss << Area << delimiter << Line << delimiter << DeviceAddress;
+    return ss.str();
+}

--- a/src/knxindividualaddress.h
+++ b/src/knxindividualaddress.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "eibclient.h"
+#include "knxexception.h"
+#include "wblib/exceptions.h"
+#include <cstdint>
+#include <sstream>
+#include <wblib/utils.h>
+
+namespace knx
+{
+    /// \brief KNX Individual Address Class
+    ///
+    /// Designed for convenient storage and conversion of a knx individual address
+    class TKnxIndividualAddress
+    {
+    public:
+        /// \brief Default constructor
+        explicit TKnxIndividualAddress() = default;
+
+        /// \brief Address constructor
+        /// \param area area of a KNX individual address
+        /// \param line line
+        /// \param deviceAddress device address
+        TKnxIndividualAddress(uint32_t area, uint32_t line, uint32_t deviceAddress);
+
+        /// \brief Constructor from string address
+        /// \param str address string. For example: "1.2.34";
+        /// \param delimiter delimiter sub address for parsing string. Default '.'
+        explicit TKnxIndividualAddress(const std::string& str, char delimiter = '.');
+
+        /// \brief Constructor from EibAddress
+        /// \param eibAddress KNX EIB address
+        explicit TKnxIndividualAddress(eibaddr_t eibAddress);
+
+        /// \brief Area getter
+        /// \return area
+        uint32_t GetArea() const;
+
+        /// \brief Line getter
+        /// \return line
+        uint32_t GetLine() const;
+
+        /// \brief Device address getter
+        /// \return device address
+        uint32_t GetDeviceAddress() const;
+
+        /// \brief KNX EIB address getter
+        /// \return a KNX EIB address
+        eibaddr_t GetEibAddress() const;
+
+        /// \brief Less operator
+        /// \param rhs right value
+        /// \return comparison result
+        bool operator<(const TKnxIndividualAddress& rhs) const;
+
+        /// \brief Equal operator
+        /// \param rhs right value
+        /// \return comparison result
+        bool operator==(const TKnxIndividualAddress& rhs) const;
+
+        /// \brief Not Equal operator
+        /// \param rhs right value
+        /// \return comparison result
+        bool operator!=(const TKnxIndividualAddress& rhs) const;
+
+        /// \brief Converting a individual address to a string
+        /// \param delimiter sub address delimiter
+        std::string ToString(char delimiter = '.') const;
+
+    private:
+        void Init(uint32_t area, uint32_t line, uint32_t deviceAddress);
+
+        uint32_t Area{0};
+        uint32_t Line{0};
+        uint32_t DeviceAddress{0};
+    };
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,9 +19,9 @@ namespace
     const auto KNX_DRIVER_STOP_TIMEOUT_S = std::chrono::seconds(60); // topic cleanup can take a lot of time
     const auto KNX_READ_TICK_PERIOD = std::chrono::milliseconds(50);
 
-    WBMQTT::TLogger ErrorLogger("ERROR: [knx] ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::RED);
-    WBMQTT::TLogger VerboseLogger("INFO: [knx] ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::WHITE, false);
-    WBMQTT::TLogger InfoLogger("INFO: [knx] ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::GREY);
+    WBMQTT::TLogger ErrorLogger("ERROR: ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::RED);
+    WBMQTT::TLogger DebugLogger("DEBUG: ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::WHITE, false);
+    WBMQTT::TLogger InfoLogger("INFO: ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::GREY);
 } // namespace
 
 int main(int argc, char** argv)
@@ -57,10 +57,10 @@ int main(int argc, char** argv)
 
 #ifdef NDEBUG
     if (verboseLevel > 0) {
-        VerboseLogger.SetEnabled(true);
+        DebugLogger.SetEnabled(true);
     }
 #else
-    VerboseLogger.SetEnabled(true);
+    DebugLogger.SetEnabled(true);
 #endif
 
     WBMQTT::TPromise<void> initialized;
@@ -91,7 +91,7 @@ int main(int argc, char** argv)
     try {
         knx::Configurator configurator(DEFAULT_CONFIG_FILE_PATH, DEFAULT_CONFIG_SCHEMA_FILE_PATH);
         if (configurator.IsDebugEnabled()) {
-            VerboseLogger.SetEnabled(true);
+            DebugLogger.SetEnabled(true);
         }
 
         auto mqttClient = WBMQTT::NewMosquittoMqttClient(mqttConfig);
@@ -109,15 +109,14 @@ int main(int argc, char** argv)
 
         mqttDriver->WaitForReady();
 
-        auto knxClientService =
-            std::make_shared<knx::TKnxClientService>(knxUrl, ErrorLogger, VerboseLogger, InfoLogger);
+        auto knxClientService = std::make_shared<knx::TKnxClientService>(knxUrl, ErrorLogger, DebugLogger, InfoLogger);
 
         std::shared_ptr<knx::TKnxLegacyDevice> knxLegacyDevice;
         if (configurator.IsKnxLegacyDeviceEnabled()) {
             knxLegacyDevice = std::make_shared<knx::TKnxLegacyDevice>(mqttDriver,
                                                                       knxClientService,
                                                                       ErrorLogger,
-                                                                      VerboseLogger,
+                                                                      DebugLogger,
                                                                       InfoLogger);
         }
         knx::TTickTimer tickTimer;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(${PROJECT_NAME}_test ${TEST_LIST}
         ../src/knxgroupobject/basedptconfig.cpp
         ../src/knxgroupobject/dptjsonconfig.cpp
         ../src/knxgroupobject/dptwbmqttconfig.cpp
+        ../src/knxindinvidualaddress.cpp
         )
 
 target_link_libraries(${PROJECT_NAME}_test gtest gtest_main gmock wbmqtt1 pthread)

--- a/test/ut_knxindividualaddress.cpp
+++ b/test/ut_knxindividualaddress.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include "../src/knxindividualaddress.h"
+
+TEST(KnxIndividualAddressTest, TrivialConstructorTest)
+{
+    uint32_t area = 1;
+    uint32_t line = 2;
+    uint32_t device = 102;
+    knx::TKnxIndividualAddress address(area, line, device);
+
+    EXPECT_EQ(area, address.GetArea());
+    EXPECT_EQ(line, address.GetLine());
+    EXPECT_EQ(device, address.GetDeviceAddress());
+}
+
+TEST(KnxIndividualAddressTest, ConstructorEibTest)
+{
+    uint32_t area = 1;
+    uint32_t line = 2;
+    uint32_t device = 102;
+    knx::TKnxIndividualAddress address(area, line, device);
+    knx::TKnxIndividualAddress address2(address.GetEibAddress());
+
+    EXPECT_EQ(area, address2.GetArea());
+    EXPECT_EQ(line, address2.GetLine());
+    EXPECT_EQ(device, address2.GetDeviceAddress());
+}
+
+TEST(KnxIndividualAddressTest, EqualOperatorTest)
+{
+    uint32_t area = 1;
+    uint32_t line = 7;
+    uint32_t device = 102;
+    knx::TKnxIndividualAddress address(area, line, device);
+    knx::TKnxIndividualAddress address2(address.GetEibAddress());
+
+    EXPECT_EQ(address, address2);
+}
+
+TEST(KnxIndividualAddressTest, LessOperatorTest)
+{
+    uint32_t area = 1;
+    uint32_t line = 2;
+    uint32_t device = 102;
+    knx::TKnxIndividualAddress address(area, line, device);
+    knx::TKnxIndividualAddress address2(area, line, device + 1);
+
+    EXPECT_LT(address, address2);
+}
+
+TEST(KnxIndividualAddressTest, ToStringTest)
+{
+    knx::TKnxIndividualAddress address(1, 2, 3);
+    EXPECT_EQ("1.2.3", address.ToString());
+    EXPECT_EQ("1/2/3", address.ToString('/'));
+}
+
+TEST(KnxIndividualAddressTest, FromStringTest)
+{
+
+    knx::TKnxIndividualAddress address{"1/2/3", '/'};
+    EXPECT_EQ("1/2/3", address.ToString('/'));
+
+    address = knx::TKnxIndividualAddress{"0.0.0"};
+    EXPECT_EQ("0.0.0", address.ToString());
+
+    address = knx::TKnxIndividualAddress{"15.7.255"};
+    EXPECT_EQ("15.7.255", address.ToString());
+}
+
+TEST(KnxIndividualAddressTest, FromStringNegativeTest)
+{
+    std::vector<std::string> addressList = {"a1.2.3", "32.2.3", "1.17.3", "1.1.256", "", "...", "65536"};
+
+    for (const auto& addtessStr: addressList) {
+        EXPECT_THROW(knx::TKnxIndividualAddress{addtessStr}, std::exception);
+    }
+}


### PR DESCRIPTION
* Поправил уровень логов для отладочного вывода.
* Создал класс индивидуальных адресов для преобразований.
* Сделал удобочитаемый отладочный вывод в лог приёма и отправки телеграмм. Индивидуальные и групповые адреса отображаются как i.i.i g/g/g соответственно.
* Сделал рефакторинг функций преобразования knx<->mqtt: уменьшил дублирование кода и упростил немного.

Отладочный лог:
![Screenshot_20220907_124427](https://user-images.githubusercontent.com/12100943/188833515-07401ce0-87b5-4d20-8d95-a6f336402b02.png)
