### PR TITLE
54016 long service stop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.12.0) stable; urgency=medium
+
+  * Reduce service downtime
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Thu, 27 Oct 2022 10:57:36 +0400
+
 wb-mqtt-knx (1.11.0) stable; urgency=medium
 
   * More readable log output

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-knx (1.12.0) stable; urgency=medium
 
-  * Reduce service downtime
+  * Reduce time to stop the service
 
  -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Thu, 27 Oct 2022 10:57:36 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-mqtt-knx (1.12.0) stable; urgency=medium
 
   * Reduce time to stop the service
+  * Add service stop if configuration file is wrong
 
  -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Thu, 27 Oct 2022 10:57:36 +0400
 

--- a/debian/wb-mqtt-knx.service
+++ b/debian/wb-mqtt-knx.service
@@ -4,8 +4,8 @@ After=knxd.service wb-hwconf-manager.service
 
 [Service]
 Type=simple
-Restart=always
-RestartSec=1
+Restart=on-failure
+RestartSec=15
 User=root
 ExecStart=/usr/bin/wb-mqtt-knx
 

--- a/debian/wb-mqtt-knx.service
+++ b/debian/wb-mqtt-knx.service
@@ -9,5 +9,7 @@ RestartSec=15
 User=root
 ExecStart=/usr/bin/wb-mqtt-knx
 
+RestartPreventExitStatus=2 3 4 5 6 7
+
 [Install]
 WantedBy=multi-user.target

--- a/src/knxclientservice.cpp
+++ b/src/knxclientservice.cpp
@@ -156,8 +156,7 @@ namespace knx
         }
 
         auto future = std::async(std::launch::async, &std::thread::join, Worker.get());
-        if (future.wait_for(CONNECTION_THREAD_TIMEOUT)
-            == std::future_status::timeout) {
+        if (future.wait_for(CONNECTION_THREAD_TIMEOUT) == std::future_status::timeout) {
             ErrorLogger.Log() << "knxd connection stop timeout";
         }
         Worker.reset();

--- a/src/knxclientservice.cpp
+++ b/src/knxclientservice.cpp
@@ -15,7 +15,7 @@
 namespace
 {
     constexpr auto RECEIVER_LOOP_TIMEOUT = std::chrono::seconds(2);
-    constexpr auto CONNECTION_THREAD_TIMEOUT = std::chrono::seconds(6);
+    constexpr auto CONNECTION_THREAD_STOP_TIMEOUT = std::chrono::seconds(6);
 
     constexpr auto MAX_TELEGRAM_LENGTH = knx::TTelegram::SizeWithoutPayload + knx::TTpdu::MaxPayloadSize;
     constexpr auto EIB_ERROR_RETURN_VALUE = -1;
@@ -156,7 +156,7 @@ namespace knx
         }
 
         auto future = std::async(std::launch::async, &std::thread::join, Worker.get());
-        if (future.wait_for(CONNECTION_THREAD_TIMEOUT) == std::future_status::timeout) {
+        if (future.wait_for(CONNECTION_THREAD_STOP_TIMEOUT) == std::future_status::timeout) {
             ErrorLogger.Log() << "knxd connection stop timeout";
         }
         Worker.reset();

--- a/src/knxclientservice.cpp
+++ b/src/knxclientservice.cpp
@@ -111,7 +111,7 @@ namespace knx
     void TKnxClientService::HandleCriticalError(const std::string& what)
     {
         ErrorLogger.Log() << what;
-        wb_throw(knx::TKnxException, what);
+        exit(EXIT_FAILURE);
     }
 
     void TKnxClientService::Start()

--- a/src/knxclientservice.h
+++ b/src/knxclientservice.h
@@ -38,6 +38,7 @@ namespace knx
         std::unique_ptr<knx::TKnxConnection> KnxdConnection;
 
         void KnxdConnectProcessing();
+        void KnxdDisconnectProcessing();
         void KnxdReceiveProcessing();
 
         void HandleCriticalError(const std::string& what);
@@ -45,8 +46,10 @@ namespace knx
         std::string KnxServerUrl;
 
         std::atomic<bool> IsStarted{false};
+        std::atomic<bool> IsConnected{false};
         std::unique_ptr<std::thread> Worker;
         std::mutex SendMutex;
+        std::mutex ActiveMutex;
 
         WBMQTT::TLogger& ErrorLogger;
         WBMQTT::TLogger& DebugLogger;

--- a/src/knxclientservice.h
+++ b/src/knxclientservice.h
@@ -40,7 +40,7 @@ namespace knx
         void KnxdConnectProcessing();
         void KnxdReceiveProcessing();
 
-        void HandleLoopError(const std::string& what);
+        void HandleCriticalError(const std::string& what);
 
         std::string KnxServerUrl;
 

--- a/src/knxgroupobject/dptjsonfield.cpp
+++ b/src/knxgroupobject/dptjsonfield.cpp
@@ -63,7 +63,7 @@ namespace knx
                     break;
                 case EFieldType::UNSIGNED_INT:
                 case EFieldType::ENUM:
-                    Value = Json::Value(value.to_ullong() & ((1 << BitWidth) - 1));
+                    Value = Json::Value(static_cast<uint64_t>(value.to_ullong() & ((1 << BitWidth) - 1)));
                     break;
                 case EFieldType::INT:
                     if (BitWidth == 8) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,10 +152,10 @@ int main(int argc, char** argv)
 
         pConfigurator->ConfigureObjectController(*knxGroupObjectController, *groupObjectBuilder);
 
-        WBMQTT::SignalHandling::Start();
-
         knxClientService->Start();
         tickTimer.Start();
+
+        WBMQTT::SignalHandling::Start();
         WBMQTT::SignalHandling::Wait();
     } catch (std::exception& e) {
         ErrorLogger.Log() << e.what();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ namespace
     const auto KNX_READ_TICK_PERIOD = std::chrono::milliseconds(50);
 
     // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
-    constexpr auto EXIT_NOTCONFIGURED = 6;   // The program is not configured
+    constexpr auto EXIT_NOTCONFIGURED = 6; // The program is not configured
 
     WBMQTT::TLogger ErrorLogger("ERROR: ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::RED);
     WBMQTT::TLogger DebugLogger("DEBUG: ", WBMQTT::TLogger::StdErr, WBMQTT::TLogger::WHITE, false);
@@ -77,7 +77,6 @@ int main(int argc, char** argv)
         ErrorLogger.Log() << "Driver takes too long to stop. Exiting.";
         exit(EXIT_FAILURE);
     });
-    WBMQTT::SignalHandling::Start();
 
     std::unique_ptr<knx::Configurator> pConfigurator;
 
@@ -85,8 +84,7 @@ int main(int argc, char** argv)
         pConfigurator = std::make_unique<knx::Configurator>(DEFAULT_CONFIG_FILE_PATH, DEFAULT_CONFIG_SCHEMA_FILE_PATH);
     } catch (std::exception& e) {
         ErrorLogger.Log() << e.what();
-        WBMQTT::SignalHandling::Stop();
-        exit(EXIT_NOTCONFIGURED);
+        return EXIT_NOTCONFIGURED;
     }
 
     try {
@@ -154,15 +152,15 @@ int main(int argc, char** argv)
 
         pConfigurator->ConfigureObjectController(*knxGroupObjectController, *groupObjectBuilder);
 
+        WBMQTT::SignalHandling::Start();
+
         knxClientService->Start();
         tickTimer.Start();
-
         WBMQTT::SignalHandling::Wait();
     } catch (std::exception& e) {
         ErrorLogger.Log() << e.what();
-        WBMQTT::SignalHandling::Stop();
-        exit(EXIT_FAILURE);
+        return EXIT_FAILURE;
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/src/ticktimer.h
+++ b/src/ticktimer.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
+#include <mutex>
 
 namespace knx
 {
@@ -28,6 +29,7 @@ namespace knx
         void Stop();
 
     private:
+        std::mutex ActiveMutex;
         void Processing();
         std::atomic<bool> IsStarted{false};
         std::unique_ptr<std::thread> Worker;

--- a/src/ticktimer.h
+++ b/src/ticktimer.h
@@ -3,8 +3,8 @@
 #include "observer.h"
 #include <atomic>
 #include <chrono>
-#include <thread>
 #include <mutex>
+#include <thread>
 
 namespace knx
 {


### PR DESCRIPTION
Вынес процесс соединения с knxd в основной поток.
Убрал задержку после получения сигналов от systemd во время старта и инициализации wb-mqtt-knx.