### PR TITLE
Enable memory checking using Valgrind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ cmake-build-*
 
 # Doxygen output files
 doc
+
+### direnv ###
+.direnv
+.envrc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ execute_process (
         OUTPUT_VARIABLE DEB_VERSION
 )
 
-
-
 # add the binary tree to the search path for include files
 # so that we will find config.h
 include_directories("${PROJECT_BINARY_DIR}")
@@ -40,7 +38,7 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
 endif ()
 
 # Adding unit tests
-enable_testing()
+include (CTest)
 add_subdirectory(test)
 
 # Added ets.xml <-> wb-mqtt-knx.conf tool

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.12.3) stable; urgency=medium
+
+  * Enable memory checking using Valgrind. No functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 19 Dec 2023 17:37:41 +0400
+
 wb-mqtt-knx (1.12.2) stable; urgency=medium
 
   * Add service dependency from mosquitto. No functional changes

--- a/etsconfigtool/CMakeLists.txt
+++ b/etsconfigtool/CMakeLists.txt
@@ -21,7 +21,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE include)
 target_link_libraries(${PROJECT_NAME} gcov tinyxml2 wbmqtt1)
 
 # Adding unit tests
-enable_testing()
 add_subdirectory(test)
 
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)

--- a/etsconfigtool/test/CMakeLists.txt
+++ b/etsconfigtool/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-enable_testing()
 aux_source_directory(./ TEST_LIST)
 aux_source_directory(./mock TEST_LIST)
 
@@ -18,7 +17,6 @@ add_executable(${PROJECT_NAME}_test ${TEST_LIST}
 target_include_directories(${PROJECT_NAME}_test PRIVATE ../include)
 
 target_link_libraries(${PROJECT_NAME}_test gtest gtest_main gmock pthread tinyxml2 wbmqtt1)
-
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     target_link_libraries(${PROJECT_NAME}_test gcov)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 
-enable_testing()
 aux_source_directory(./ TEST_LIST)
 aux_source_directory(./mock TEST_LIST)
 
@@ -40,7 +39,6 @@ add_executable(${PROJECT_NAME}_test ${TEST_LIST}
         )
 
 target_link_libraries(${PROJECT_NAME}_test gtest gtest_main gmock wbmqtt1 pthread)
-
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     target_link_libraries(${PROJECT_NAME}_test gcov)

--- a/test/mock/knxtelegramsender.h
+++ b/test/mock/knxtelegramsender.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#pragma once
-
 #include "../../src/isender.h"
 #include "../../src/knxtelegram.h"
 #include "gmock/gmock.h"

--- a/test/ut_configurator.cpp
+++ b/test/ut_configurator.cpp
@@ -35,9 +35,6 @@ TEST_F(ConfiguratorTest, GetIncorrectConfig)
 
 TEST_F(ConfiguratorTest, NoConfig)
 {
-    StrictMock<TKnxGroupObjectControllerMock> goController;
-    TGroupObjectMqttBuilderMock groupObjectMqttBuilder;
-
     EXPECT_THROW(std::make_unique<knx::Configurator>(".", SourceDir + "/wb-mqtt-knx.schema.json"), std::exception);
 }
 


### PR DESCRIPTION
`memcheck` action doesn't work now:
```sh
$ ctest -T memcheck
Cannot find file: /home/sikmir/Projects/wb-mqtt-knx/build/DartConfiguration.tcl
   Build name: (empty)
Create new tag: 20231219-1926 - Experimental
Cannot find file: /home/sikmir/Projects/wb-mqtt-knx/build/DartConfiguration.tcl
Memory check project /home/sikmir/Projects/wb-mqtt-knx/build
Memory checker (MemoryCheckCommand) not set, or cannot find the specified program.
Errors while running CTest
Output from these tests are in: /home/sikmir/Projects/wb-mqtt-knx/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
```

To use memory checking tools from CMake, CTest module should be included as `include(CTest)` instead of just enabling tests with `enable_testing()`.

Result:
```sh
$ ctest -T memcheck
   Build name: Linux-g++
Memory check project /home/sikmir/Projects/wb-mqtt-knx/build
    Start 1: wb-mqtt-knx_test
1/2 MemCheck #1: wb-mqtt-knx_test .................   Passed    2.84 sec
    Start 2: wb-knx-ets-tool_test
2/2 MemCheck #2: wb-knx-ets-tool_test .............   Passed    2.82 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   5.67 sec
-- Processing memory checking output:
1/2 MemCheck: #1: wb-mqtt-knx_test .................   Defects: 2
MemCheck log files can be found here: (<#> corresponds to test number)
/home/sikmir/Projects/wb-mqtt-knx/build/Testing/Temporary/MemoryChecker.<#>.log
Memory checking results:
Potential Memory Leak - 2
```