### PR TITLE
Add help printout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-mqtt-knx (1.12.6) stable; urgency=medium
+
+  * Add help printout
+  * Add -u/-P/-T mqtt arguments
+  * Add -c argument to specify config file
+  * Fix debug logging level setting
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 30 Jan 2024 13:01:00 +0400
+
 wb-mqtt-knx (1.12.5) stable; urgency=medium
 
   * Add arm64 build, no functional changes


### PR DESCRIPTION
  * Add help printout
```sh
Usage: wb-mqtt-knx [options]
Options:
  -d       level     enable debuging output:
                       1 - knx only;
                       2 - mqtt only;
                       3 - both;
                       negative values - silent mode (-1, -2, -3))
  -c       config    config file (default: /etc/wb-mqtt-knx.conf)
  -p       port      MQTT broker port (default: 1883)
  -H       IP        MQTT broker IP (default: localhost)
  -u       user      MQTT user (optional)
  -P       password  MQTT user password (optional)
  -T       prefix    MQTT topic prefix (optional)
  -k       url       KNX url (default: ip:localhost:6720)
```
  * Add -u/-P/-T mqtt arguments
  * Add -c argument to specify custom config file
  * Fix debug logging level setting (mqtt logging)