### PR TITLE
Fix crash on arm64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-knx (1.12.8) stable; urgency=medium
+
+  * Fix crash on arm64
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 06 May 2024 11:45:00 +0400
+
 wb-mqtt-knx (1.12.7) stable; urgency=medium
 
   * Add device title translations

--- a/src/knxclientservice.cpp
+++ b/src/knxclientservice.cpp
@@ -172,12 +172,12 @@ namespace knx
 
         auto duration = std::chrono::duration_cast<std::chrono::microseconds>(RECEIVER_LOOP_TIMEOUT);
 
-        struct timeval tv;
-        tv.tv_sec = duration.count() / 1000000;
-        tv.tv_usec = duration.count() % 1000000;
-
         // The loop responsible for receiving telegrams from knxd
         while (IsStarted) {
+            struct timeval tv;
+            tv.tv_sec = duration.count() / 1000000;
+            tv.tv_usec = duration.count() % 1000000;
+
             fd_set set;
             FD_ZERO(&set);
             FD_SET(linuxFileDescriptor, &set);

--- a/src/knxclientservice.cpp
+++ b/src/knxclientservice.cpp
@@ -168,10 +168,16 @@ namespace knx
         if (linuxFileDescriptor == EIB_ERROR_RETURN_VALUE) {
             HandleCriticalError("Failed to get Poll fd");
         }
+        DebugLogger.Log() << "Poll fd: " << linuxFileDescriptor;
+
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(RECEIVER_LOOP_TIMEOUT);
+
+        struct timeval tv;
+        tv.tv_sec = duration.count() / 1000000;
+        tv.tv_usec = duration.count() % 1000000;
+
         // The loop responsible for receiving telegrams from knxd
         while (IsStarted) {
-            struct timeval tv = {0,
-                                 std::chrono::duration_cast<std::chrono::microseconds>(RECEIVER_LOOP_TIMEOUT).count()};
             fd_set set;
             FD_ZERO(&set);
             FD_SET(linuxFileDescriptor, &set);


### PR DESCRIPTION
```sh
$ wb-mqtt-knx
...
<3>ERROR: Select failed: Invalid argument
terminate called without an active exception
fish: 'wb-mqtt-knx' terminated by signal SIGABRT (Abort)
```