### PR TITLE
Add coverage report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.qm
 .#*
 *.*#
+build
 core
 !core/
 tags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_compile_options(-Wall -Werror -pedantic)
 
 if (CMAKE_BUILD_TYPE MATCHES Debug)
     add_compile_options(-O0 -gdwarf-3 --coverage)
+    add_link_options(--coverage)
 else ()
     add_compile_options(-O2 -DNDEBUG)
 endif ()
@@ -32,10 +33,6 @@ aux_source_directory(src/knxgroupobject SRC_LIST)
 
 add_executable(${PROJECT_NAME} ${SRC_LIST})
 target_link_libraries(${PROJECT_NAME} wbmqtt1 eibclient pthread)
-
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-    target_link_libraries(${PROJECT_NAME} gcov)
-endif ()
 
 # Adding unit tests
 include (CTest)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
-               defaultStyleCheckDirs: 'src test'
+               defaultStyleCheckDirs: 'src test',
+               defaultRunCoverage: false,
+               defaultCoverageMin: '75'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: '75'
+               defaultCoverageMin: '79'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+wb-mqtt-knx (1.13.2) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 20:10:00 +0400
+
 wb-mqtt-knx (1.13.1) stable; urgency=medium
 
   * Add dependency from libwbmqtt1-5. No functional changes
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com> Tue, 17 Sep 2024 13:50:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 17 Sep 2024 13:50:00 +0400
 
 wb-mqtt-knx (1.13.0) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -4,13 +4,14 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 10),
-               pkg-config,
+               gcovr:all,
+               libgtest-dev,
+               libgmock-dev,
+               libtinyxml2-dev,
                libwbmqtt1-5-dev,
                knxd-dev (>= 0.14.51-1),
                knxd-tools (>= 0.14.51-1),
-               libtinyxml2-dev,
-               libgtest-dev,
-               libgmock-dev
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-knx/
 
 Package: wb-mqtt-knx

--- a/debian/rules
+++ b/debian/rules
@@ -1,13 +1,28 @@
 #!/usr/bin/make -f
 
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+GCOVR_FLAGS := -s
+ifneq ($(COV_REPORT),)
+	GCOVR_FLAGS += --html $(COV_REPORT)
+endif
+ifneq ($(COV_FAIL_UNDER),)
+	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
+endif
+
 %:
 	dh $@ --parallel
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-		-DCMAKE_BUILD_TYPE=$(if $(findstring debug, $(DEB_BUILD_OPTIONS)),Debug,Release) \
-		-DCOV_FAIL_UNDER=$(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS))) \
-		-DCOV_REPORT=$(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+		-DCMAKE_BUILD_TYPE=$(if $(findstring debug, $(DEB_BUILD_OPTIONS)),Debug,Release)
+
+override_dh_auto_test:
+	dh_auto_test
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	gcovr $(GCOVR_FLAGS) .
+endif
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OP
 
 GCOVR_FLAGS := -s
 ifneq ($(COV_REPORT),)
-	GCOVR_FLAGS += --html $(COV_REPORT)
+	GCOVR_FLAGS += --html $(COV_REPORT).html -x $(COV_REPORT).xml
 endif
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)

--- a/debian/rules
+++ b/debian/rules
@@ -3,5 +3,11 @@
 %:
 	dh $@ --parallel
 
+override_dh_auto_configure:
+	dh_auto_configure -- \
+		-DCMAKE_BUILD_TYPE=$(if $(findstring debug, $(DEB_BUILD_OPTIONS)),Debug,Release) \
+		-DCOV_FAIL_UNDER=$(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS))) \
+		-DCOV_REPORT=$(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/etsconfigtool/CMakeLists.txt
+++ b/etsconfigtool/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${PROJECT_NAME} ${SRC_FILES_LIST}
 
 target_include_directories(${PROJECT_NAME} PRIVATE include)
 
-target_link_libraries(${PROJECT_NAME} gcov tinyxml2 wbmqtt1)
+target_link_libraries(${PROJECT_NAME} tinyxml2 wbmqtt1)
 
 # Adding unit tests
 add_subdirectory(test)

--- a/etsconfigtool/test/CMakeLists.txt
+++ b/etsconfigtool/test/CMakeLists.txt
@@ -18,8 +18,4 @@ target_include_directories(${PROJECT_NAME}_test PRIVATE ../include)
 
 target_link_libraries(${PROJECT_NAME}_test gtest gtest_main gmock pthread tinyxml2 wbmqtt1)
 
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-    target_link_libraries(${PROJECT_NAME}_test gcov)
-endif ()
-
 add_test(${PROJECT_NAME}_test ${PROJECT_NAME}_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,8 +40,4 @@ add_executable(${PROJECT_NAME}_test ${TEST_LIST}
 
 target_link_libraries(${PROJECT_NAME}_test gtest gtest_main gmock wbmqtt1 pthread)
 
-if (CMAKE_BUILD_TYPE MATCHES Debug)
-    target_link_libraries(${PROJECT_NAME}_test gcov)
-endif ()
-
 add_test(${PROJECT_NAME}_test ${PROJECT_NAME}_test)


### PR DESCRIPTION
How to use (with devcontainer):
```sh
(cd build; cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON "-GUnix Makefiles" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=armv7l -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g\\+\\+ -DPKG_CONFIG_EXECUTABLE=/usr/bin/arm-linux-gnueabihf-pkg-config -DPKGCONFIG_EXECUTABLE=/usr/bin/arm-linux-gnueabihf-pkg-config -DQMAKE_EXECUTABLE=/usr/bin/arm-linux-gnueabihf-qmake -DCMAKE_INSTALL_LIBDIR=lib/arm-linux-gnueabihf -DCMAKE_BUILD_TYPE=Debug ..)
(cd build; make test)
gcovr --html build/cov.html build
open build/cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=79 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-10-2 kello 11 28 27" src="https://github.com/user-attachments/assets/0ca45c25-1781-456d-a44c-184d1d4f999e">
