### PR TITLE
Set meta/error on knxd socket error, enable persistence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,3 +52,4 @@ install(FILES ${PROJECT_SOURCE_DIR}/wb-mqtt-knx.schema.json DESTINATION /usr/sha
 install(FILES ${PROJECT_SOURCE_DIR}/wb-mqtt-knx.conf DESTINATION /etc)
 install(FILES ${PROJECT_SOURCE_DIR}/wb-mqtt-knx-jsondpt.conf DESTINATION /usr/share/wb-mqtt-knx)
 install(FILES ${PROJECT_SOURCE_DIR}/wb-mqtt-knx.wbconfigs DESTINATION /etc/wb-configs.d RENAME 42wb-mqtt-knx)
+install(DIRECTORY DESTINATION /var/lib/wb-mqtt-knx)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-knx (1.13.3) stable; urgency=medium
+
+  * Set meta/error on knxd socket error
+  * Enable control value persistence
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 08 Oct 2024 16:30:00 +0400
+
 wb-mqtt-knx (1.13.2) stable; urgency=medium
 
   * Add coverage report generation, no functional changes
@@ -220,4 +227,3 @@ wb-mqtt-knx (0.1) unstable; urgency=medium
   * Initial release.
 
  -- Yury Usishchev <y.usishchev@contactless.ru>  Thu, 1 Dec 2016 23:04:28 +0400
-

--- a/src/knxgroupobject/mqttbuilder.cpp
+++ b/src/knxgroupobject/mqttbuilder.cpp
@@ -21,7 +21,7 @@ void TGroupObjectMqttBuilder::LinkDevice(const std::string& id, const std::strin
     MqttDeviceList.push_back(
         MqttDeviceDriver->BeginTx()
             ->CreateDevice(
-                WBMQTT::TLocalDeviceArgs{}.SetId(id).SetTitle(name).SetIsVirtual(true).SetDoLoadPrevious(false))
+                WBMQTT::TLocalDeviceArgs{}.SetId(id).SetTitle(name).SetIsVirtual(true).SetDoLoadPrevious(true))
             .GetValue());
 }
 

--- a/src/knxgroupobjectcontroller.cpp
+++ b/src/knxgroupobjectcontroller.cpp
@@ -58,6 +58,11 @@ void TKnxGroupObjectController::Notify(const TKnxEvent& event, const TTelegram& 
                 Send({address, telegram::TApci::GroupValueRead, {0}});
             }
         }
+    } else if (event == TKnxEvent::KnxdSocketError) {
+        for (auto& itemPair: GroupObjectList) {
+            auto& item = itemPair.second;
+            item->GroupObject->KnxNotifyEvent(TKnxEvent::KnxdSocketError);
+        }
     } else if (event != TKnxEvent::ReceivedTelegram) {
         return;
     }

--- a/src/knxgroupobjectcontroller.cpp
+++ b/src/knxgroupobjectcontroller.cpp
@@ -58,13 +58,11 @@ void TKnxGroupObjectController::Notify(const TKnxEvent& event, const TTelegram& 
                 Send({address, telegram::TApci::GroupValueRead, {0}});
             }
         }
-    } else if (event == TKnxEvent::KnxdSocketError) {
-        for (auto& itemPair: GroupObjectList) {
-            auto& item = itemPair.second;
-            item->GroupObject->KnxNotifyEvent(TKnxEvent::KnxdSocketError);
-        }
-    } else if (event != TKnxEvent::ReceivedTelegram) {
-        return;
+    }
+
+    for (auto& itemPair: GroupObjectList) {
+        auto& item = itemPair.second;
+        item->GroupObject->KnxNotifyEvent(event);
     }
 
     if (knxTelegram.IsGroupAddressed()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,8 @@ namespace
     const auto KNX_DRIVER_STOP_TIMEOUT_S = std::chrono::seconds(60); // topic cleanup can take a lot of time
     const auto KNX_READ_TICK_PERIOD = std::chrono::milliseconds(50);
 
+    const auto LIBWBMQTT_DB_FULL_FILE_PATH = "/var/lib/wb-mqtt-knx/libwbmqtt.db";
+
     // https://refspecs.linuxbase.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
     constexpr auto EXIT_NOTCONFIGURED = 6; // The program is not configured
 
@@ -167,7 +169,8 @@ int main(int argc, char** argv)
         auto mqttDriver = WBMQTT::NewDriver(WBMQTT::TDriverArgs{}
                                                 .SetId(PROJECT_NAME)
                                                 .SetBackend(WBMQTT::NewDriverBackend(mqttClient))
-                                                .SetUseStorage(false)
+                                                .SetUseStorage(true)
+                                                .SetStoragePath(LIBWBMQTT_DB_FULL_FILE_PATH)
                                                 .SetReownUnknownDevices(true));
         mqttDriver->StartLoop();
 

--- a/test/ut_knxgroupobjectcontroller.cpp
+++ b/test/ut_knxgroupobjectcontroller.cpp
@@ -81,7 +81,9 @@ TEST_F(KnxGroupObjectControllerTest, ReadRequestAfterStart)
     auto groupObjectMock = std::make_shared<TGroupObjectMock>();
     EXPECT_CALL(*groupObjectMock, SetKnxSender(address, _)).Times(1);
     EXPECT_CALL(*TelegramSender, Send(_)).Times(1);
-
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
+    }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
     eventObserverStub.Subscribe(Controller);
     tickTimerObserverStub.Subscribe(Controller);
@@ -110,7 +112,9 @@ TEST_F(KnxGroupObjectControllerTest, SendTelegram)
         EXPECT_EQ(telegram.Tpdu().GetPayload(), payload);
         EXPECT_EQ(telegram.GetReceiverAddress(), address.GetEibAddress());
     }));
-
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
+    }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
     goSender->Send(knx::object::TGroupObjectTransaction{address, knx::telegram::TApci::GroupValueWrite, payload});
     eventObserverStub.Subscribe(Controller);
@@ -144,7 +148,11 @@ TEST_F(KnxGroupObjectControllerTest, RecvTelegram)
             EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
             EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
         }));
-
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
+    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
+    }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
 
     eventObserverStub.Subscribe(Controller);
@@ -182,7 +190,15 @@ TEST_F(KnxGroupObjectControllerTest, RecvFeedbackTelegram)
             EXPECT_EQ(knxFeedbackTelegram.Tpdu().GetAPCI(), transaction.Apci);
             EXPECT_EQ(knxFeedbackTelegram.Tpdu().GetPayload(), transaction.Payload);
         }));
-
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
+    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
+    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
+    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
+    }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
 
     eventObserverStub.Subscribe(Controller);
@@ -219,7 +235,11 @@ TEST_F(KnxGroupObjectControllerTest, PollRead)
             EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
             EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
         }));
-
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
+    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
+    }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
     EXPECT_CALL(*TelegramSender, Send(_)).WillOnce(Invoke([](const knx::TTelegram& telegram) {
         EXPECT_EQ(telegram.Tpdu().GetAPCI(), knx::telegram::TApci::GroupValueRead);
@@ -263,11 +283,13 @@ TEST_F(KnxGroupObjectControllerTest, PollReadTimeout)
             EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
             EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
         }));
-
     EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
+    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
         EXPECT_EQ(event, knx::TKnxEvent::PollReadTimeoutError);
+    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
+        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
     }));
-
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
     EXPECT_CALL(*TelegramSender, Send(_)).WillOnce(Invoke([](const knx::TTelegram& telegram) {
         EXPECT_EQ(telegram.Tpdu().GetAPCI(), knx::telegram::TApci::GroupValueRead);

--- a/test/ut_knxgroupobjectcontroller.cpp
+++ b/test/ut_knxgroupobjectcontroller.cpp
@@ -148,11 +148,9 @@ TEST_F(KnxGroupObjectControllerTest, RecvTelegram)
             EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
             EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
         }));
-    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
-    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
-    }));
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected); }))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram); }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
 
     eventObserverStub.Subscribe(Controller);
@@ -190,15 +188,11 @@ TEST_F(KnxGroupObjectControllerTest, RecvFeedbackTelegram)
             EXPECT_EQ(knxFeedbackTelegram.Tpdu().GetAPCI(), transaction.Apci);
             EXPECT_EQ(knxFeedbackTelegram.Tpdu().GetPayload(), transaction.Payload);
         }));
-    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
-    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
-    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
-    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
-    }));
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected); }))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected); }))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram); }))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram); }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
 
     eventObserverStub.Subscribe(Controller);
@@ -235,11 +229,9 @@ TEST_F(KnxGroupObjectControllerTest, PollRead)
             EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
             EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
         }));
-    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
-    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
-    }));
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected); }))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram); }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
     EXPECT_CALL(*TelegramSender, Send(_)).WillOnce(Invoke([](const knx::TTelegram& telegram) {
         EXPECT_EQ(telegram.Tpdu().GetAPCI(), knx::telegram::TApci::GroupValueRead);
@@ -283,13 +275,10 @@ TEST_F(KnxGroupObjectControllerTest, PollReadTimeout)
             EXPECT_EQ(knxTelegram.Tpdu().GetAPCI(), transaction.Apci);
             EXPECT_EQ(knxTelegram.Tpdu().GetPayload(), transaction.Payload);
         }));
-    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_)).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected);
-    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::PollReadTimeoutError);
-    })).WillOnce(Invoke([](const knx::TKnxEvent& event) {
-        EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram);
-    }));
+    EXPECT_CALL(*groupObjectMock, KnxNotifyEvent(_))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::KnxdSocketConnected); }))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::PollReadTimeoutError); }))
+        .WillOnce(Invoke([](const knx::TKnxEvent& event) { EXPECT_EQ(event, knx::TKnxEvent::ReceivedTelegram); }));
     EXPECT_TRUE(Controller->AddGroupObject(groupObjectMock, goSettings));
     EXPECT_CALL(*TelegramSender, Send(_)).WillOnce(Invoke([](const knx::TTelegram& telegram) {
         EXPECT_EQ(telegram.Tpdu().GetAPCI(), knx::telegram::TApci::GroupValueRead);


### PR DESCRIPTION
  * Set meta/error on knxd socket error
  * Enable control value persistence
  * Reconnect to knxd without restart
 
```sh
echo "deb http://deb.wirenboard.com/all experimental.knx main" > /etc/apt/sources.list.d/knx.list
```